### PR TITLE
EditListItem socket connection

### DIFF
--- a/frontend/src/controllers/DataController.js
+++ b/frontend/src/controllers/DataController.js
@@ -61,9 +61,9 @@ class DataController {
       throw new Error(message);
     }
     const data = await response.json();
-
+    // Convert JSON object containing items keyed by their IDs to an ES6 Map
     const itemMap = new Map(
-      data.Items.map((item) => [item.id, new DormItem(item)])
+      Object.keys(data.items).map((key) => [key, new DormItem(data.items[key])])
     );
 
     // Static data for testing purposes
@@ -114,7 +114,6 @@ class DataController {
         listID: roomID,
         name: "Fridge",
         quantity: 4,
-        editable: false,
       }),
     });
     if (!itemResponse1.ok) {
@@ -132,7 +131,6 @@ class DataController {
         listID: roomID,
         name: "Microwave",
         quantity: 1,
-        editable: true,
       }),
     });
     if (!itemResponse2.ok) {

--- a/frontend/src/controllers/SocketConnection.js
+++ b/frontend/src/controllers/SocketConnection.js
@@ -7,9 +7,15 @@ class SocketConnection {
     };
   }
 
+  // Receives incoming messages and parses the data JS objects
   set onMessage(callback) {
     this.connection.onmessage = (evt) => {
-      callback(evt);
+      try {
+        const data = JSON.parse(evt.data);
+        callback(data);
+      } catch (e) {
+        console.error("Error parsing socket message data: ", e);
+      }
     };
   }
 

--- a/frontend/src/routes/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute.js
@@ -73,8 +73,9 @@ class RoomRoute extends Component {
       event: "itemUpdated",
       data: {
         itemID: item.id,
-        property: "editorPosition",
-        value: item.editorPosition,
+        updated: {
+          editorPosition: item.editorPosition,
+        },
       },
     });
   };

--- a/frontend/src/routes/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute.js
@@ -68,7 +68,7 @@ class RoomRoute extends Component {
 
   // Callback passed to RoomCanvas for when item is updated
   itemUpdatedInEditor = (item) => {
-    console.log("ITEM", item.id, "UPDATED");
+    console.log("ITEM", item.id, item, "UPDATED");
     this.state.socketConnection.send({
       event: "itemUpdated",
       data: {

--- a/frontend/src/routes/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute.js
@@ -24,8 +24,8 @@ class RoomRoute extends Component {
     this.getItemMap();
   }
 
-  onReceiveSocketMessage = (message) => {
-    console.log("RECEIVED", message);
+  onReceiveSocketMessage = (data) => {
+    console.log("RECEIVED", data);
   };
 
   onSocketConnectionClosed = (message) => {
@@ -68,7 +68,7 @@ class RoomRoute extends Component {
 
   // Callback passed to RoomCanvas for when item is updated
   itemUpdatedInEditor = (item) => {
-    console.log("ITEM", item.id, item, "UPDATED");
+    // console.log("ITEM", item.id, item, "UPDATED");
     this.state.socketConnection.send({
       event: "itemUpdated",
       data: {

--- a/models/list.go
+++ b/models/list.go
@@ -13,8 +13,8 @@ type ListItem struct {
 	ClaimedBy string `json:"claimedBy"`
 	Editable bool `json:"editable"`
 	EditorPosition *struct {
-		X float32 `json:"x"`
-		Y float32 `json:"y"`
+		X string `json:"x"`
+		Y string `json:"y"`
 	} `json:"editorPosition"`
 }
 
@@ -101,9 +101,17 @@ func EditListItem(database *rdb.Session, id string, itemID string, property stri
 	for _, item := range data.Items {
 		if item.ID == itemID {
 			if property == "editorPosition" {
-				coord := value.(map[string]float32)
-				item.EditorPosition.X = coord["x"]
-				item.EditorPosition.Y = coord["Y"]
+				coord := value.(map[string]interface{})
+			
+				x := coord["x"].(float64)
+				y := coord["y"].(float64)
+
+				// TODO: change the position from string to float32 or int, 
+				// but the conversion is kinda finicky...
+				if item.EditorPosition != nil {
+					item.EditorPosition.X = fmt.Sprintf("%f", x)
+					item.EditorPosition.Y = fmt.Sprintf("%f", y)				
+				}
 			}
 			
 			updateErr := rdb.DB("dd-data").Table("lists").Get(id).Update(data).Exec(database)

--- a/models/list.go
+++ b/models/list.go
@@ -84,3 +84,37 @@ func AddListItem(database *rdb.Session, id string, item ListItem) {
 		fmt.Println(updateErr)
 	}
 }
+
+func EditListItem(database *rdb.Session, id string, itemID string, property string, value interface{}) ListItem {
+	res, err := rdb.DB("dd-data").Table("lists").Get(id).Run(database)
+
+	var data List
+	res.One(&data)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	defer res.Close()
+
+	/* TODO: replace the data.Items with a map to avoid this */
+	for _, item := range data.Items {
+		if item.ID == itemID {
+			if property == "editorPosition" {
+				coord := value.(map[string]float32)
+				item.EditorPosition.X = coord["x"]
+				item.EditorPosition.Y = coord["Y"]
+			}
+			
+			updateErr := rdb.DB("dd-data").Table("lists").Get(id).Update(data).Exec(database)
+
+			if updateErr != nil {
+				fmt.Println(updateErr)
+			}
+			
+			return item
+		}
+	}
+
+	return ListItem{}
+}

--- a/models/list.go
+++ b/models/list.go
@@ -12,10 +12,12 @@ type ListItem struct {
 	Quantity int `json:"quantity"`
 	ClaimedBy string `json:"claimedBy"`
 	Editable bool `json:"editable"`
-	EditorPosition *struct {
-		X string `json:"x"`
-		Y string `json:"y"`
-	} `json:"editorPosition"`
+	EditorPosition *EditorPoint `json:"editorPosition"`
+}
+
+type EditorPoint struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
 }
 
 type List struct {
@@ -108,12 +110,17 @@ func EditListItem(database *rdb.Session, id string, itemID string, property stri
 
 				// TODO: change the position from string to float32 or int, 
 				// but the conversion is kinda finicky...
-				if item.EditorPosition != nil {
-					item.EditorPosition.X = fmt.Sprintf("%f", x)
-					item.EditorPosition.Y = fmt.Sprintf("%f", y)				
+				if item.EditorPosition == nil {
+					item.EditorPosition = &EditorPoint{
+						X: x,
+						Y: y,
+					}
+				} else {
+					item.EditorPosition.X = x
+					item.EditorPosition.Y = y
 				}
 			}
-			
+
 			updateErr := rdb.DB("dd-data").Table("lists").Get(id).Update(data).Exec(database)
 
 			if updateErr != nil {

--- a/routes.go
+++ b/routes.go
@@ -9,8 +9,8 @@ import (
 	rdb "gopkg.in/rethinkdb/rethinkdb-go.v6"
 )
 
-func SetupSockets(e *echo.Echo) {
-	hub := sockets.CreateHub()
+func SetupSockets(e *echo.Echo, database *rdb.Session) {
+	hub := sockets.CreateHub(database)
 	go hub.Run()
 
 	e.GET("/ws", func(c echo.Context) error {
@@ -22,7 +22,7 @@ func SetupSockets(e *echo.Echo) {
 
 // SetupRoutes: configures the API endpoints
 func SetupRoutes(e *echo.Echo, database *rdb.Session) {
-	SetupSockets(e)
+	SetupSockets(e, database)
 	
 	listRoute := routes.ListRoute{ Database: database }
 

--- a/routes/list.go
+++ b/routes/list.go
@@ -94,7 +94,6 @@ func (route *ListRoute) OnAddListItem(c echo.Context) error {
 		ID: itemID,
 		Name: form.Name,					// If not provided in form, will be ""
 		Quantity: form.Quantity,	// If not provided in form, will be 0
-		Editable: form.Editable,	// If not provided in form, will be false
 		EditorPosition: nil,
 	}
 	fmt.Println("Added item:", item)

--- a/routes/list.go
+++ b/routes/list.go
@@ -20,7 +20,6 @@ type ItemForm struct {
 	ItemID string `json:"id" form:"id"`
 	Name string `json:"name" form:"name"`
 	Quantity int `json:"quantity" form:"quantity"`
-	Editable bool `json:"editable" form:"editable"`
 }
 
 func (route *ListRoute) OnGetList(c echo.Context) error {

--- a/sockets/client.go
+++ b/sockets/client.go
@@ -124,13 +124,19 @@ func (c *Client) translateMessage(byteMessage []byte) (Message, error) {
 		value := data["value"]
 
 		updatedItem := models.EditListItem(c.hub.database, roomID, itemID, property, value)
-		itemJson, itemJsonErr := json.Marshal(updatedItem)
-
-		if itemJsonErr != nil {
-			return Message{}, itemJsonErr
+		_ = updatedItem
+		response := MessageResponse{
+			Event: "itemUpdated",
+			Data: updatedItem,
 		}
 
-		return Message{ room: roomID, sender: c, content: itemJson }, nil
+		responseBytes, responseBytesErr := json.Marshal(response)
+
+		if responseBytesErr != nil {
+			return Message{}, responseBytesErr
+		}
+	
+		return Message{ room: roomID, sender: c, response: responseBytes }, nil
 
 	case "itemDeleted":
 		/*

--- a/sockets/client.go
+++ b/sockets/client.go
@@ -120,14 +120,25 @@ func (c *Client) translateMessage(byteMessage []byte) (Message, error) {
 		*/
 
 		itemID := data["itemID"].(string)
-		property := data["property"].(string)
-		value := data["value"]
+		// Get map of updated properties and their values
+		updated := data["updated"].(map[string]interface{})
+	
 
-		updatedItem := models.EditListItem(c.hub.database, roomID, itemID, property, value)
-		_ = updatedItem
+		item, err := models.EditListItem(c.hub.database, roomID, itemID, updated)
+		log.Println("ITEM", (*item).EditorPosition)
+		if err != nil {
+			return Message{}, err
+		}
+		
 		response := MessageResponse{
 			Event: "itemUpdated",
-			Data: updatedItem,
+			Data: struct{
+				ID string `json:"id"`
+				Updated map[string]interface{} `json:"updated"`
+			}{
+				ID: itemID,
+				Updated: updated,
+			},
 		}
 
 		responseBytes, responseBytesErr := json.Marshal(response)

--- a/sockets/client.go
+++ b/sockets/client.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"encoding/json"
 	"errors"
+	"fmt"
 
+	"github.com/gmisail/dormdesign/models"
 	"github.com/labstack/echo/v4"
 	"github.com/gorilla/websocket"
 )
@@ -68,7 +70,7 @@ func (c *Client) readPump() {
 			break
 		}
 		
-		message, err := translateMessage(byteMessage)
+		message, err := c.translateMessage(byteMessage)
 		if err != nil {
 			log.Println(err)
 		} else {	// Only forward message to hub if its valid
@@ -79,7 +81,7 @@ func (c *Client) readPump() {
 }
 
 // Takes in raw message data and returns a Message object if its valid. Otherwise, returns error.
-func translateMessage(byteMessage []byte) (Message, error) {
+func (c *Client) translateMessage(byteMessage []byte) (Message, error) {
 	var message interface{}
 
 	// Decode JSON data
@@ -117,7 +119,14 @@ func translateMessage(byteMessage []byte) (Message, error) {
 		/*
 			Update property/properties of existing ListItem
 		*/
-		return Message{}, errors.New("Event1 not supported yet")
+
+		itemID := data["itemID"].(string)
+		property := data["property"].(string)
+		value := data["value"]
+
+		updatedItem := models.EditListItem(c.hub.database, roomID, itemID, property, value)
+
+		return Message{ room: roomID, sender: c, content: updatedItem }, errors.New("[itemUpdated]")
 
 	case "itemDeleted":
 		/*

--- a/sockets/client.go
+++ b/sockets/client.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/gmisail/dormdesign/models"
 	"github.com/labstack/echo/v4"
@@ -125,8 +124,13 @@ func (c *Client) translateMessage(byteMessage []byte) (Message, error) {
 		value := data["value"]
 
 		updatedItem := models.EditListItem(c.hub.database, roomID, itemID, property, value)
+		itemJson, itemJsonErr := json.Marshal(updatedItem)
 
-		return Message{ room: roomID, sender: c, content: updatedItem }, errors.New("[itemUpdated]")
+		if itemJsonErr != nil {
+			return Message{}, itemJsonErr
+		}
+
+		return Message{ room: roomID, sender: c, content: itemJson }, nil
 
 	case "itemDeleted":
 		/*

--- a/sockets/hub.go
+++ b/sockets/hub.go
@@ -7,7 +7,11 @@ import (
 type Message struct {
 	room string
 	sender *Client
-	content []byte
+	response []byte
+}
+type MessageResponse struct {
+	Event string `json:"event"`
+	Data interface{} `json:"data"`
 }
 
 type Room struct {
@@ -87,9 +91,14 @@ func (h *Hub) Run() {
 			room := h.rooms[message.room]
 
 			if room != nil {
+				// Send message to all clients in the room
 				for client := range room.Clients {
+					// Don't send message back to person who originally sent it
+					if (client == message.sender) {
+						continue
+					}
 					select {
-					case client.send <- message.content:
+					case client.send <- message.response:
 					default:
 						h.RemoveClient(client.id, client)
 					}

--- a/sockets/hub.go
+++ b/sockets/hub.go
@@ -1,5 +1,9 @@
 package sockets
 
+import (
+	rdb "gopkg.in/rethinkdb/rethinkdb-go.v6"
+)
+
 type Message struct {
 	room string
 	sender *Client
@@ -11,14 +15,16 @@ type Room struct {
 }
 
 type Hub struct {
+	database *rdb.Session
 	rooms map[string]*Room
 	broadcast chan Message
 	register chan *Client
 	unregister chan *Client
 }
 
-func CreateHub() *Hub {
+func CreateHub(database *rdb.Session) *Hub {
 	return &Hub{
+		database: database,
 		broadcast: make(chan Message),
 		register: make(chan *Client),
 		unregister: make(chan *Client),


### PR DESCRIPTION
This update should allow changes to be send to the server and then sent back to all of the connected clients. While this is working, the updated data is only sent back to the original client while all other clients get `null`. For instance, let's say the new position is `x_i, y_i`. The original client gets: `{... editorPosition: { x: x_i, y: y_i } ... }` while all of the others get `{... editorPosition: null ... }`. I could have made a mistake somewhere in the code, but let me know if you can reproduce this issue first.