### PR TITLE
Added event controller to send event on edit

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,8 +6,11 @@ import { BrowserRouter as Router, Route } from "react-router-dom";
 import "../node_modules/bootstrap/dist/css/bootstrap.min.css";
 import RoomRoute from "./routes/RoomRoute";
 import HomeRoute from "./routes/HomeRoute";
+import EventController from "./controllers/EventController";
 
 function App() {
+  EventController.create();
+
   return (
     <Router>
       <NavigationBar></NavigationBar>

--- a/frontend/src/components/RoomCanvas/RoomCanvas.js
+++ b/frontend/src/components/RoomCanvas/RoomCanvas.js
@@ -3,6 +3,7 @@ import "./RoomCanvas.css";
 import SceneController from "../../room-editor/SceneController";
 import RoomObject from "../../room-editor/RoomObject";
 import Vector2 from "../../room-editor/Vector2";
+import EventController from "../../controllers/EventController";
 
 class RoomCanvas extends Component {
   constructor(props) {
@@ -46,6 +47,12 @@ class RoomCanvas extends Component {
       scene: scene,
       roomObject: room,
     });
+
+    EventController.on("itemUpdated", (payload) => {
+      room.updateRoomItem(payload.id, {
+        position: payload.updated.editorPosition,
+      });
+    });
   }
 
   componentDidUpdate(prevProps) {
@@ -77,26 +84,6 @@ class RoomCanvas extends Component {
         j++;
       }
     }
-  }
-
-  // Takes in editor data for object and tries to update the corresponding object in the editor scene
-  updateRoomObject(args) {
-    const { id, item, itemEditorData, sceneObject } = args;
-
-    // If no scene object provided, try and get it from the scene by id
-    const obj = sceneObject ?? this.state.scene.objects.get(id);
-    if (!obj) {
-      console.error(
-        `Error updating object with id ${id}. Couldn't find corresponding scene object with matching id.`
-      );
-      return;
-    }
-    this.state.roomObject.updateRoomItem(id, {
-      position: itemEditorData.position,
-      name: item.name,
-      width: item.dimensions.w,
-      height: item.dimensions.l,
-    });
   }
 
   // Called when object is moved in room. Updates item's position and calls callback function

--- a/frontend/src/controllers/EventController.js
+++ b/frontend/src/controllers/EventController.js
@@ -1,0 +1,25 @@
+class EventController {
+  static create() {
+    this.events = [];
+  }
+
+  static on(evt, callback) {
+    if (!this.events[evt]) {
+      this.events[evt] = [];
+    }
+
+    this.events[evt].push(callback);
+  }
+
+  static emit(evt, payload) {
+    if (this.events[evt]) {
+      this.events[evt].forEach((element) => {
+        element(payload);
+      });
+    } else {
+      throw new Error("Cannot find event with name '" + evt + "'");
+    }
+  }
+}
+
+export default EventController;

--- a/frontend/src/room-editor/RoomObject.js
+++ b/frontend/src/room-editor/RoomObject.js
@@ -78,7 +78,11 @@ class RoomObject extends SceneObject {
 
     this.objectColors = ["#0043E0", "#f28a00", "#C400E0", "#7EE016", "#0BE07B"];
 
-    //    EventController.on("itemUpdated", this.test)
+    EventController.on("itemUpdated", (payload) => {
+      this.updateRoomItem(payload.id, {
+        position: payload.updated.editorPosition,
+      });
+    });
   }
 
   // Fills any area between the boundary of the room and the bounding box of the RoomObject itself with a box. Returns that list of boxes

--- a/frontend/src/room-editor/RoomObject.js
+++ b/frontend/src/room-editor/RoomObject.js
@@ -1,3 +1,4 @@
+import EventController from "../controllers/EventController";
 import SceneObject from "./SceneObject";
 import MouseController from "./MouseController";
 import Collisions from "./Collisions";
@@ -76,6 +77,8 @@ class RoomObject extends SceneObject {
     this.state.floorGrid = floorGrid;
 
     this.objectColors = ["#0043E0", "#f28a00", "#C400E0", "#7EE016", "#0BE07B"];
+
+    //    EventController.on("itemUpdated", this.test)
   }
 
   // Fills any area between the boundary of the room and the bounding box of the RoomObject itself with a box. Returns that list of boxes

--- a/frontend/src/room-editor/RoomObject.js
+++ b/frontend/src/room-editor/RoomObject.js
@@ -1,4 +1,3 @@
-import EventController from "../controllers/EventController";
 import SceneObject from "./SceneObject";
 import MouseController from "./MouseController";
 import Collisions from "./Collisions";
@@ -77,12 +76,6 @@ class RoomObject extends SceneObject {
     this.state.floorGrid = floorGrid;
 
     this.objectColors = ["#0043E0", "#f28a00", "#C400E0", "#7EE016", "#0BE07B"];
-
-    EventController.on("itemUpdated", (payload) => {
-      this.updateRoomItem(payload.id, {
-        position: payload.updated.editorPosition,
-      });
-    });
   }
 
   // Fills any area between the boundary of the room and the bounding box of the RoomObject itself with a box. Returns that list of boxes

--- a/frontend/src/routes/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute.js
@@ -6,6 +6,7 @@ import DormItemList from "../components/DormItemList/DormItemList";
 import ListItemForm from "../components/ListItemForm/ListItemForm";
 import DataController from "../controllers/DataController";
 import SocketConnection from "../controllers/SocketConnection";
+import EventController from "../controllers/EventController";
 
 class RoomRoute extends Component {
   constructor() {
@@ -26,6 +27,8 @@ class RoomRoute extends Component {
 
   onReceiveSocketMessage = (data) => {
     console.log("RECEIVED", data);
+
+    EventController.emit(data.event, data.data);
   };
 
   onSocketConnectionClosed = (message) => {


### PR DESCRIPTION
I made a simple event emitter so that we can simply call `EventController.on(event, callback)` to set up events and `EventController.emit(event, payload)` when a socket is received. I am not sure if this is totally necessary, but it is much easier for sending data to the list and editor unless you want to use Redux or something. So basically, this should (in theory) replace (or rather emulate) Socket.io's client API.  