### PR TITLE
Add/Edit Socket Events

### DIFF
--- a/frontend/src/components/ListItemForm/ListItemForm.js
+++ b/frontend/src/components/ListItemForm/ListItemForm.js
@@ -7,6 +7,7 @@ class ListItemForm extends Component {
   constructor(props) {
     super(props);
     let item = props.item;
+    // Name for new items should be blank
     const name = item ? item.name : "";
     if (!item) {
       item = new DormItem();
@@ -15,8 +16,8 @@ class ListItemForm extends Component {
     let width = "",
       length = "";
     if (item.dimensions) {
-      width = item.dimensions.w ?? "";
-      length = item.dimensions.l ?? "";
+      width = item.dimensions.width ?? "";
+      length = item.dimensions.length ?? "";
     }
 
     this.state = {
@@ -26,7 +27,7 @@ class ListItemForm extends Component {
       ownerInputValue: item.claimedBy ?? "",
       widthInputValue: width,
       lengthInputValue: length,
-      editableValue: item.editable,
+      visibleInEditorValue: item.visibleInEditor,
       validated: false,
     };
   }
@@ -68,9 +69,9 @@ class ListItemForm extends Component {
           : this.state.ownerInputValue;
       const width = parseFloat(this.state.widthInputValue);
       const length = parseFloat(this.state.lengthInputValue);
-      item.dimensions.w = isNaN(width) ? undefined : width;
-      item.dimensions.l = isNaN(length) ? undefined : length;
-      item.editable = this.state.editableValue;
+      item.dimensions.width = isNaN(width) ? undefined : width;
+      item.dimensions.length = isNaN(length) ? undefined : length;
+      item.visibleInEditor = this.state.visibleInEditorValue;
       this.props.onSubmit(item);
     }
   };
@@ -153,9 +154,9 @@ class ListItemForm extends Component {
         </Form.Group>
         <Form.Group>
           <Form.Check
-            label="Add to Room Editor"
-            name="editableValue"
-            checked={this.state.editableValue}
+            label="Show in Room Editor"
+            name="visibleInEditorValue"
+            checked={this.state.visibleInEditorValue}
             onChange={this.handleInputChange}
           />
         </Form.Group>

--- a/frontend/src/components/ListItemForm/ListItemForm.js
+++ b/frontend/src/components/ListItemForm/ListItemForm.js
@@ -24,7 +24,7 @@ class ListItemForm extends Component {
       item: item,
       nameInputValue: name,
       qtyInputValue: item.quantity,
-      ownerInputValue: item.claimedBy ?? "",
+      claimedByInputValue: item.claimedBy ?? "",
       widthInputValue: width,
       lengthInputValue: length,
       visibleInEditorValue: item.visibleInEditor,
@@ -44,7 +44,7 @@ class ListItemForm extends Component {
       }
     } else if (name === "nameInputValue") {
       value = value.substring(0, 30);
-    } else if (name === "ownerInputValue") {
+    } else if (name === "claimedByInputValue") {
       value = value.substring(0, 30);
     }
 
@@ -53,6 +53,12 @@ class ListItemForm extends Component {
     });
   };
 
+  /*
+  Called when form is submitted. If form fields are valid, returns item ID and an object containing the DormItem
+  fields that were modified and their new values. Currently property values are in a form that is ready
+  to be sent and interpreted by the Golang backend, meaning undefined values are instead set to Golang
+  zero values (e.g. "" for strings)
+  */
   onFormSubmit = (event) => {
     const form = event.currentTarget;
     event.preventDefault();
@@ -60,19 +66,65 @@ class ListItemForm extends Component {
     if (form.checkValidity() === false) {
       event.stopPropagation();
     } else {
+      let {
+        nameInputValue,
+        qtyInputValue,
+        widthInputValue,
+        lengthInputValue,
+        visibleInEditorValue,
+        claimedByInputValue,
+      } = this.state;
       let item = this.state.item;
-      item.name = this.state.nameInputValue;
-      item.quantity = parseInt(this.state.qtyInputValue);
-      item.claimedBy =
-        this.state.ownerInputValue.length === 0
-          ? undefined
-          : this.state.ownerInputValue;
-      const width = parseFloat(this.state.widthInputValue);
-      const length = parseFloat(this.state.lengthInputValue);
-      item.dimensions.width = isNaN(width) ? undefined : width;
-      item.dimensions.length = isNaN(length) ? undefined : length;
-      item.visibleInEditor = this.state.visibleInEditorValue;
-      this.props.onSubmit(item);
+      let modifiedProperties = {};
+      if (nameInputValue !== item.name) {
+        modifiedProperties.name = nameInputValue;
+      }
+      if (qtyInputValue !== item.quantity) {
+        modifiedProperties.quantity = parseInt(qtyInputValue);
+      }
+
+      // If NaN set to 0 (which is treated like undefined)
+      if (isNaN(widthInputValue)) {
+        widthInputValue = 0;
+      } else {
+        widthInputValue = parseFloat(widthInputValue);
+      }
+      if (isNaN(lengthInputValue)) {
+        lengthInputValue = 0;
+      } else {
+        lengthInputValue = parseFloat(lengthInputValue);
+      }
+
+      // If dimension values aren't zero, compare them with old item dimensions. Otherwise, check if item values are undefined
+      const widthEqual =
+        widthInputValue !== 0
+          ? Math.abs(widthInputValue - item.dimensions.width) < 0.0001
+          : item.dimensions.width === undefined;
+      const lengthEqual =
+        lengthInputValue !== 0
+          ? Math.abs(lengthInputValue - item.dimensions.length) < 0.0001
+          : item.dimensions.length === undefined;
+      if (!widthEqual || !lengthEqual) {
+        modifiedProperties.dimensions = {
+          width: widthInputValue,
+          length: lengthInputValue,
+          height: 0, // TODO: replace when form has a height field
+        };
+      }
+
+      // claimbedBy == "" and a previous value of undefined means no change.
+      if (
+        (claimedByInputValue.length === 0 && item.claimedBy !== undefined) ||
+        (claimedByInputValue.length !== 0 &&
+          claimedByInputValue !== item.claimedBy)
+      ) {
+        modifiedProperties.claimbedBy = claimedByInputValue;
+      }
+      if (visibleInEditorValue !== item.visibleInEditor) {
+        modifiedProperties.visibleInEditor = visibleInEditorValue;
+      }
+
+      this.props.onSubmit(item.id, modifiedProperties);
     }
   };
 
@@ -117,8 +169,8 @@ class ListItemForm extends Component {
         <Form.Group controlId="formItemOwner">
           <Form.Label>Name of Owner</Form.Label>
           <Form.Control
-            name="ownerInputValue"
-            value={this.state.ownerInputValue}
+            name="claimedByInputValue"
+            value={this.state.claimedByInputValue}
             placeholder="Name of the person that this belongs too"
             onChange={this.handleInputChange}
           />

--- a/frontend/src/components/ListItemForm/ListItemForm.js
+++ b/frontend/src/components/ListItemForm/ListItemForm.js
@@ -84,15 +84,13 @@ class ListItemForm extends Component {
       }
 
       // If NaN set to 0 (which is treated like undefined)
+      widthInputValue = parseFloat(widthInputValue);
+      lengthInputValue = parseFloat(lengthInputValue);
       if (isNaN(widthInputValue)) {
         widthInputValue = 0;
-      } else {
-        widthInputValue = parseFloat(widthInputValue);
       }
       if (isNaN(lengthInputValue)) {
         lengthInputValue = 0;
-      } else {
-        lengthInputValue = parseFloat(lengthInputValue);
       }
 
       // If dimension values aren't zero, compare them with old item dimensions. Otherwise, check if item values are undefined
@@ -118,7 +116,7 @@ class ListItemForm extends Component {
         (claimedByInputValue.length !== 0 &&
           claimedByInputValue !== item.claimedBy)
       ) {
-        modifiedProperties.claimbedBy = claimedByInputValue;
+        modifiedProperties.claimedBy = claimedByInputValue;
       }
       if (visibleInEditorValue !== item.visibleInEditor) {
         modifiedProperties.visibleInEditor = visibleInEditorValue;

--- a/frontend/src/components/RoomCanvas/RoomCanvas.js
+++ b/frontend/src/components/RoomCanvas/RoomCanvas.js
@@ -3,7 +3,6 @@ import "./RoomCanvas.css";
 import SceneController from "../../room-editor/SceneController";
 import RoomObject from "../../room-editor/RoomObject";
 import Vector2 from "../../room-editor/Vector2";
-import EventController from "../../controllers/EventController";
 
 class RoomCanvas extends Component {
   constructor(props) {
@@ -47,12 +46,6 @@ class RoomCanvas extends Component {
       scene: scene,
       roomObject: room,
     });
-
-    EventController.on("itemUpdated", (payload) => {
-      room.updateRoomItem(payload.id, {
-        position: payload.updated.editorPosition,
-      });
-    });
   }
 
   componentDidUpdate(prevProps) {
@@ -80,11 +73,38 @@ class RoomCanvas extends Component {
         this.removeItemFromScene(b);
         j++;
       } else {
+        // Update item in case its properties changed
+        this.updateRoomObject(a);
         i++;
         j++;
       }
     }
   }
+
+  // Takes in item ID and tries to update the corresponding object in the editor scene
+  updateRoomObject = (id) => {
+    console.log(id);
+    const item = this.props.itemMap.get(id);
+    if (!item) {
+      console.error(
+        `ERROR Updating item in room editor. Invalid item ID: ${id}`
+      );
+    }
+    // Try and fetch corresponding scene object
+    const obj = this.state.scene.objects.get(id);
+    if (!obj) {
+      console.error(
+        `ERROR updating object with id ${id}. Couldn't find corresponding scene object with matching id.`
+      );
+      return;
+    }
+    this.state.roomObject.updateRoomItem(id, {
+      position: item.editorPosition,
+      name: item.name,
+      width: item.dimensions.width,
+      height: item.dimensions.length, // Since editor is 2D, use length for Y dimension
+    });
+  };
 
   // Called when object is moved in room. Updates item's position and calls callback function
   roomObjectUpdated = (obj) => {

--- a/frontend/src/components/RoomCanvas/RoomCanvas.js
+++ b/frontend/src/components/RoomCanvas/RoomCanvas.js
@@ -83,7 +83,6 @@ class RoomCanvas extends Component {
 
   // Takes in item ID and tries to update the corresponding object in the editor scene
   updateRoomObject = (id) => {
-    console.log(id);
     const item = this.props.itemMap.get(id);
     if (!item) {
       console.error(

--- a/frontend/src/components/RoomCanvas/RoomCanvas.js
+++ b/frontend/src/components/RoomCanvas/RoomCanvas.js
@@ -58,7 +58,7 @@ class RoomCanvas extends Component {
   componentDidUpdate(prevProps) {
     // Filter out items not included in editor
     const includedItems = [...this.props.itemMap.values()].filter(
-      (item) => item.editable
+      (item) => item.visibleInEditor
     );
 
     // Sort included items and currently added objects by id
@@ -109,8 +109,8 @@ class RoomCanvas extends Component {
     const newObj = this.state.roomObject.addItemToRoom({
       id: item.id,
       name: item.name,
-      feetWidth: item.dimensions.w,
-      feetHeight: item.dimensions.l,
+      feetWidth: item.dimensions.width,
+      feetHeight: item.dimensions.length,
       position: item.editorPosition,
     });
     // If item had no position, update item data with new position set by the room (should be in center of room by default)

--- a/frontend/src/controllers/DataController.js
+++ b/frontend/src/controllers/DataController.js
@@ -50,8 +50,7 @@ class DataController {
   //Retrieves the List's data from the server.
   static async getList(id) {
     if (!id) {
-      console.error("Failed to fetch list. Room ID is undefined");
-      return;
+      throw new Error("Can't fetch room data. Room ID is undefined");
     }
 
     const response = await fetch(`/list/get?id=${id}`);
@@ -61,17 +60,15 @@ class DataController {
       throw new Error(message);
     }
     const data = await response.json();
-    // Convert JSON object containing items keyed by their IDs to an ES6 Map
-    const itemMap = new Map(
-      Object.keys(data.items).map((key) => [key, new DormItem(data.items[key])])
-    );
 
-    // Static data for testing purposes
-    // const itemMap = new Map(
-    //   TEST_ITEMS_DATA.map((item) => [item.id, new DormItem(item)])
-    // );
+    if (!data.items) {
+      throw new Error("ERROR Room items missing from fetch room response");
+    }
 
-    return itemMap;
+    const items = data.items.map((item) => {
+      return new DormItem(item);
+    });
+    return items;
   }
 
   /*

--- a/frontend/src/controllers/SocketConnection.js
+++ b/frontend/src/controllers/SocketConnection.js
@@ -10,11 +10,14 @@ class SocketConnection {
   // Receives incoming messages and parses the data JS objects
   set onMessage(callback) {
     this.connection.onmessage = (evt) => {
+      let data = undefined;
       try {
-        const data = JSON.parse(evt.data);
-        callback(data);
+        data = JSON.parse(evt.data);
       } catch (e) {
         console.error("Error parsing socket message data: ", e);
+      }
+      if (data) {
+        callback(data);
       }
     };
   }

--- a/frontend/src/models/DormItem.js
+++ b/frontend/src/models/DormItem.js
@@ -5,23 +5,24 @@ class DormItem {
       name,
       quantity,
       claimedBy,
-      width,
-      length,
-      height,
-      editable,
+      dimensions,
+      visibleInEditor,
       editorPosition,
     } = data ?? {};
     this.id = id;
     this.name = name === undefined || name.length === 0 ? "New Item" : name;
-    this.quantity = quantity === 0 ? undefined : quantity;
+    this.quantity = quantity ?? 1;
     this.claimedBy =
       claimedBy === undefined || claimedBy.length === 0 ? undefined : claimedBy;
-    this.dimensions = {
-      width: width,
-      length: length,
-      height: height,
-    };
-    this.editable = editable ?? false;
+
+    this.dimensions = dimensions
+      ? {
+          width: dimensions.width,
+          length: dimensions.length,
+          height: dimensions.height,
+        }
+      : { width: undefined, length: undefined, height: undefined };
+    this.visibleInEditor = visibleInEditor ?? false;
     this.editorPosition = editorPosition;
   }
 }

--- a/frontend/src/models/DormItem.js
+++ b/frontend/src/models/DormItem.js
@@ -17,9 +17,10 @@ class DormItem {
 
     this.dimensions = dimensions
       ? {
-          width: dimensions.width,
-          length: dimensions.length,
-          height: dimensions.height,
+          // If dimensions are 0 (default value from backend), set as undefined
+          width: dimensions.width === 0 ? undefined : dimensions.width,
+          length: dimensions.length === 0 ? undefined : dimensions.length,
+          height: dimensions.height === 0 ? undefined : dimensions.height,
         }
       : { width: undefined, length: undefined, height: undefined };
     this.visibleInEditor = visibleInEditor ?? false;

--- a/frontend/src/room-editor/RoomObject.js
+++ b/frontend/src/room-editor/RoomObject.js
@@ -298,7 +298,10 @@ class RoomObject extends SceneObject {
   // Updates object in room. Returns true if successful false if not
   updateRoomItem(id, { position, name, width, height }) {
     const obj = this.scene.objects.get(id);
-    if (!obj) return false;
+    if (!obj) {
+      console.error("ERROR updating room item. Invalid object ID: " + id);
+      return;
+    }
     if (position) {
       obj.setPosition(new Vector2(position.x, position.y));
     }

--- a/frontend/src/room-editor/RoomObject.js
+++ b/frontend/src/room-editor/RoomObject.js
@@ -302,7 +302,7 @@ class RoomObject extends SceneObject {
       console.error("ERROR updating room item. Invalid object ID: " + id);
       return;
     }
-    if (position) {
+    if (position && position.x && position.y) {
       obj.setPosition(new Vector2(position.x, position.y));
     }
     if (name) {

--- a/frontend/src/routes/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute.js
@@ -94,6 +94,7 @@ class RoomRoute extends Component {
     this.toggleModal("edit");
   };
 
+  // Receives item ID and list of modified properties when ListItemForm is submitted
   editItemFormSubmit = (itemID, modified) => {
     this.state.socketConnection.send({
       event: "updateItem",
@@ -107,12 +108,11 @@ class RoomRoute extends Component {
     this.toggleModal();
   };
 
-  addNewItem = (item) => {
+  // Receives item ID and list of modified properties when ListItemForm is submitted
+  addNewItem = (itemID, modified) => {
     this.state.socketConnection.send({
       event: "addItem",
-      data: {
-        ...item,
-      },
+      data: modified,
     });
 
     this.toggleModal();
@@ -148,7 +148,7 @@ class RoomRoute extends Component {
               <Modal.Title>Add an Item</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-              <ListItemForm onSubmit={this.addNewItem.bind(this)} />
+              <ListItemForm onSubmit={this.addNewItem} />
             </Modal.Body>
           </Modal>
         );

--- a/frontend/src/routes/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute.js
@@ -41,7 +41,6 @@ class RoomRoute extends Component {
     const connection = new SocketConnection(roomID);
     // When socket connection receives message, notify EventController
     connection.onMessage = (data) => {
-      console.log("RECEIVED: ", data);
       if (data.event) {
         EventController.emit(data.event, data.data);
       } else {
@@ -87,7 +86,6 @@ class RoomRoute extends Component {
         item.quantity = updated.quantity;
       }
       this.setState({ itemMap: new Map(this.state.itemMap) });
-      console.log(data);
     });
   };
 
@@ -97,7 +95,6 @@ class RoomRoute extends Component {
   };
 
   editItemFormSubmit = (itemID, modified) => {
-    console.log(modified);
     this.state.socketConnection.send({
       event: "updateItem",
       respond: true,
@@ -107,11 +104,6 @@ class RoomRoute extends Component {
       },
     });
 
-    // this.state.itemMap.set(item.id, editedItem);
-    // // In order for react to register that map has changed, need to copy map values to new map
-    // this.setState({ itemMap: new Map(this.state.itemMap) });
-
-    // this.setState({ editingItem: undefined });
     this.toggleModal();
   };
 

--- a/frontend/src/routes/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute.js
@@ -62,6 +62,31 @@ class RoomRoute extends Component {
       // In order for react to register that map has changed, need to copy map values to new map
       this.setState({ itemMap: new Map(this.state.itemMap) });
     });
+
+    EventController.on("itemUpdated", (payload) => {
+      // console.log(payload);
+      const item = this.state.itemMap.get(payload.id);
+      const updated = payload.updated;
+      if (updated.editorPosition) {
+        item.editorPosition = updated.editorPosition;
+      }
+      if (updated.dimensions) {
+        item.dimensions = updated.dimensions;
+      }
+      if (updated.name) {
+        item.name = updated.name;
+      }
+      if (updated.claimedBy) {
+        item.claimedBy = updated.claimedBy;
+      }
+      if (updated.visibleInEditor) {
+        item.visibleInEditor = updated.visibleInEditor;
+      }
+      if (updated.quantity) {
+        item.quantity = updated.quantity;
+      }
+      this.setState({ itemMap: new Map(this.state.itemMap) });
+    });
   };
 
   editItem = (item) => {
@@ -73,9 +98,16 @@ class RoomRoute extends Component {
     const item = this.state.editingItem;
     const editedItem = await DataController.editListItem(item);
 
-    this.state.itemMap.set(item.id, editedItem);
-    // In order for react to register that map has changed, need to copy map values to new map
-    this.setState({ itemMap: new Map(this.state.itemMap) });
+    this.state.socketConnection.send({
+      event: "editItem",
+      data: {
+        ...item,
+      },
+    });
+
+    // this.state.itemMap.set(item.id, editedItem);
+    // // In order for react to register that map has changed, need to copy map values to new map
+    // this.setState({ itemMap: new Map(this.state.itemMap) });
 
     this.setState({ editingItem: undefined });
     this.toggleModal();

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/labstack/echo/v4 v4.1.17
+	github.com/mitchellh/mapstructure v1.3.3
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
+github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=

--- a/models/list.go
+++ b/models/list.go
@@ -111,12 +111,13 @@ func EditListItem(database *rdb.Session, id string, itemID string, updated map[s
 	if !ok {
 		return nil, errors.New("ERROR Updating ListItem. Unable to find item matching id: " + itemID)
 	}
+	
 	for property, value := range updated {
 		switch property {
 		case "name": 
 			item.Name = value.(string)
 		case "quantity":
-			item.Quantity = value.(int)
+			item.Quantity = int(value.(float64))
 		case "claimbedBy":
 			item.ClaimedBy = value.(string)
 		case "visibleInEditor":

--- a/models/list.go
+++ b/models/list.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"errors"
 	rdb "gopkg.in/rethinkdb/rethinkdb-go.v6"
 )
@@ -11,12 +10,20 @@ type ListItem struct {
 	Name string `json:"name" rethinkdb:"name"`
 	Quantity int `json:"quantity" rethinkdb:"quantity"`
 	ClaimedBy string `json:"claimedBy" rethinkdb:"claimedBy"`
-	EditorPosition *EditorPoint `json:"editorPosition"`
+	VisibleInEditor bool `json:"visibleInEditor" rethinkdb:"visibleInEditor"`
+	Dimensions ItemDimensions `json:"dimensions" rethinkdb:"dimensions"`
+	EditorPosition EditorPoint `json:"editorPosition"`
+}
+
+type ItemDimensions struct {
+	Width float64 `json:"width" rethinkdb:"width"`
+	Length float64 `json:"length" rethinkdb:"length"`
+	Height float64 `json:"height" rethinkdb:"height"`
 }
 
 type EditorPoint struct {
-	X float64 `json:"x"`
-	Y float64 `json:"y"`
+	X float64 `json:"x" rethinkdb:"x"`
+	Y float64 `json:"y" rethinkdb:"y"`
 }
 
 type List struct {
@@ -27,12 +34,14 @@ type List struct {
 /*
 	Create an empty list with the given ID
 */
-func CreateList(database *rdb.Session, id string) {
+func CreateList(database *rdb.Session, id string) error {
 	err := rdb.DB("dd-data").Table("lists").Insert(List{ ID: id, Items: map[string]ListItem{} }).Exec(database)
 
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
+	
+	return nil
 }
 
 /*
@@ -42,7 +51,6 @@ func GetList(database *rdb.Session, id string) (List, error) {
 	res, err := rdb.DB("dd-data").Table("lists").Get(id).Run(database)
 
 	if err != nil {
-		fmt.Println(err)
 		return List{}, err
 	}
 
@@ -53,7 +61,6 @@ func GetList(database *rdb.Session, id string) (List, error) {
 		err = errors.New("List not found")
 	}
 	if err != nil {
-		fmt.Println(err)
 		return List{}, err
 	}
 
@@ -63,28 +70,29 @@ func GetList(database *rdb.Session, id string) (List, error) {
 }
 
 /*
-	Add a list item to the list at the given ID
+	Add a list item to the list at the given room ID
 */
-func AddListItem(database *rdb.Session, id string, item ListItem) {
-	res, err := rdb.DB("dd-data").Table("lists").Get(id).Run(database)
+func AddListItem(database *rdb.Session, roomID string, item ListItem) error {
+	res, err := rdb.DB("dd-data").Table("lists").Get(roomID).Run(database)
 
 	var data List
 	res.One(&data)
 
 	if err != nil {
-		fmt.Println(err)
+		return err;
 	}
 
 	defer res.Close()
 
 	data.Items[item.ID] = item
 
-	updateErr := rdb.DB("dd-data").Table("lists").Get(id).Update(data).Exec(database)
+	updateErr := rdb.DB("dd-data").Table("lists").Get(roomID).Update(data).Exec(database)
 
 	if updateErr != nil {
-		fmt.Println(updateErr)
+		return updateErr;
 	}
 
+	return nil
 }
 
 func EditListItem(database *rdb.Session, id string, itemID string, updated map[string]interface{}) (*ListItem, error) {
@@ -94,34 +102,39 @@ func EditListItem(database *rdb.Session, id string, itemID string, updated map[s
 	res.One(&data)
 
 	if err != nil {
-		fmt.Println(err)
+		return nil, err
 	}
 
 	defer res.Close()
 
 	item, ok := data.Items[itemID]
 	if !ok {
-		return nil, errors.New("Error updating ListItem. Unable to find item matching id: " + itemID)
+		return nil, errors.New("ERROR Updating ListItem. Unable to find item matching id: " + itemID)
 	}
 	for property, value := range updated {
 		switch property {
+		case "name": 
+			item.Name = value.(string)
+		case "quantity":
+			item.Quantity = value.(int)
+		case "claimbedBy":
+			item.ClaimedBy = value.(string)
+		case "visibleInEditor":
+			item.VisibleInEditor = value.(bool)
+		case "dimensions":
+			dimensions := value.(map[string]interface{})
+			item.Dimensions.Width = dimensions["width"].(float64)
+			item.Dimensions.Length = dimensions["length"].(float64)
+			item.Dimensions.Height = dimensions["height"].(float64)
+
 		case "editorPosition":
 			coord := value.(map[string]interface{})
 		
-			x := coord["x"].(float64)
-			y := coord["y"].(float64)
+			item.EditorPosition.X = coord["x"].(float64)
+			item.EditorPosition.Y = coord["y"].(float64)
 
-			if item.EditorPosition == nil {
-				item.EditorPosition = &EditorPoint{
-					X: x,
-					Y: y,
-				}
-			} else {
-				item.EditorPosition.X = x
-				item.EditorPosition.Y = y
-			}
 		default:
-			return nil, errors.New("Error updating ListItem. Unknown property: " + property)
+			return nil, errors.New("ERROR Updating ListItem. Unknown property: " + property)
 		}
 	}
 

--- a/sockets/client.go
+++ b/sockets/client.go
@@ -159,7 +159,7 @@ func (c *Client) translateMessage(byteMessage []byte) (Message, error) {
 			return Message{}, err
 		}
 
-		log.Printf("\nUPDATED ITEM %s %+v\n", itemID, updated)
+		log.Printf("UPDATED ITEM %s %+v\n", itemID, updated)
 		
 		response := MessageResponse{
 			Event: "itemUpdated",

--- a/sockets/hub.go
+++ b/sockets/hub.go
@@ -6,7 +6,7 @@ import (
 
 type Message struct {
 	room string
-	excludeSender bool
+	includeSender bool
 	sender *Client
 	response []byte
 }
@@ -94,8 +94,8 @@ func (h *Hub) Run() {
 			if room != nil {
 				// Send message to all clients in the room
 				for client := range room.Clients {
-					// If excludeSender flag, don't send message back to client that originally sent it
-					if (message.excludeSender && client == message.sender) {
+					// If includeSender flag, send message back to client that originally sent it
+					if (!message.includeSender && client == message.sender) {
 						continue
 					}
 					select {

--- a/sockets/hub.go
+++ b/sockets/hub.go
@@ -6,6 +6,7 @@ import (
 
 type Message struct {
 	room string
+	excludeSender bool
 	sender *Client
 	response []byte
 }
@@ -93,8 +94,8 @@ func (h *Hub) Run() {
 			if room != nil {
 				// Send message to all clients in the room
 				for client := range room.Clients {
-					// Don't send message back to person who originally sent it
-					if (client == message.sender) {
+					// If excludeSender flag, don't send message back to client that originally sent it
+					if (message.excludeSender && client == message.sender) {
 						continue
 					}
 					select {


### PR DESCRIPTION
This adds an "addItem" event and replaces the existing "updateItem" event with "editItem". It turns out that we really need a separate event for updating item positions in the editor since that event is called so rapidly. When it was generalized into the "editItem" event, it ended up being pretty slow because of the way React updates its state. So I created a new "updateItemPosition" event that is directly listened for in the RoomCanvas component. 

I also think that it makes sense to have distinct sending/response events. For example, a client would send an "editItem" event to the server, and then if its valid and successful, the server would send back an "itemEdited" event, which the client would then use to update the element. I guess they could be named the same, but I think it makes it clearer to phrase them the way I did.

I also ended up changing the array of items on the frontend back to an array instead of a map since its more performant when it needs to be frequently remade (which it does in order for React to detect state changes when items are updated). This probably isn't a necessary change since I originally did it to solve the performance issues with the generalized "updateItem" event, so it might be better to go back to a map in the future. 

And, because of this I also changed the backend List model back to storing and array of ListItems instead of a map, since it simplifies serving it to the frontend. Although I'm not sure if this is best either and again it may be that a map is more performant. Not really sure though which is better in Rethinkdb.