### PR TITLE
Claim button using local name

### DIFF
--- a/frontend/src/components/ChooseNameForm/ChooseNameForm.js
+++ b/frontend/src/components/ChooseNameForm/ChooseNameForm.js
@@ -1,0 +1,62 @@
+import React, { Component } from "react";
+import { Button } from "react-bootstrap";
+import Form from "react-bootstrap/Form";
+
+class ChooseNameForm extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      name: "",
+      validated: false,
+    };
+  }
+
+  handleInputChange = (event) => {
+    const target = event.target;
+    var value = target.value;
+
+    this.setState({
+      name: value,
+    });
+  };
+
+  onFormSubmit = (event) => {
+    event.preventDefault();
+    this.setState({ validated: true });
+
+    this.props.onSubmit(this.state.name.trim());
+  };
+
+  render() {
+    return (
+      <Form
+        noValidate
+        validated={this.state.validated}
+        onSubmit={this.onFormSubmit}
+      >
+        <Form.Group controlId="formItemName">
+          <Form.Label>Name</Form.Label>
+          <Form.Control
+            name="nameValue"
+            value={this.state.nameInputValue}
+            placeholder="Johnny Appleseed"
+            onChange={this.handleInputChange}
+            required
+          />
+          <Form.Control.Feedback type="invalid">
+            Please choose a name.
+          </Form.Control.Feedback>
+        </Form.Group>
+
+        <div className="text-right">
+          <Button variant="primary" type="submit">
+            Save
+          </Button>
+        </div>
+      </Form>
+    );
+  }
+}
+
+export default ChooseNameForm;

--- a/frontend/src/components/ChooseNameForm/ChooseNameForm.js
+++ b/frontend/src/components/ChooseNameForm/ChooseNameForm.js
@@ -23,7 +23,12 @@ class ChooseNameForm extends Component {
 
   onFormSubmit = (event) => {
     event.preventDefault();
+    const form = event.currentTarget;
     this.setState({ validated: true });
+    if (form.checkValidity() === false) {
+      event.stopPropagation();
+      return;
+    }
 
     this.props.onSubmit(this.state.name.trim());
   };
@@ -35,7 +40,7 @@ class ChooseNameForm extends Component {
         validated={this.state.validated}
         onSubmit={this.onFormSubmit}
       >
-        <Form.Group controlId="formItemName">
+        <Form.Group controlId="formUserName">
           <Form.Label>Name</Form.Label>
           <Form.Control
             name="nameValue"

--- a/frontend/src/components/DormItemList/DormItemList.js
+++ b/frontend/src/components/DormItemList/DormItemList.js
@@ -4,7 +4,7 @@ import { ListGroup } from "react-bootstrap";
 import ListItem from "../ListItem/ListItem";
 
 const DormItemList = (props) => {
-  const { items, onEditItem } = props;
+  const { items, onEditItem, onClaimItem } = props;
 
   return (
     <ListGroup>
@@ -17,6 +17,7 @@ const DormItemList = (props) => {
               key={item.id}
               item={item}
               onEdit={() => onEditItem(item)}
+              onClaim={() => onClaimItem(item)}
             />
           );
         })

--- a/frontend/src/components/ListItem/ListItem.js
+++ b/frontend/src/components/ListItem/ListItem.js
@@ -10,6 +10,12 @@ const ListItem = (props) => {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef(null);
 
+  // Called when a button in menu is clicked. Closes the menu and calls passed callback
+  const menuOptionClicked = (callback) => {
+    setShowMenu(false);
+    callback();
+  };
+
   useEffect(() => {
     // Clicked outside of menu
     function handleClickOutside(event) {
@@ -25,7 +31,7 @@ const ListItem = (props) => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [menuRef]);
-  
+
   return (
     <ListGroupItem>
       <div className="d-flex justify-content-between align-items-center">
@@ -49,9 +55,9 @@ const ListItem = (props) => {
             {showMenu ? (
               <div className="item-dropdown-content">
                 <ul>
-                  <li onClick={onEdit}>Edit</li>
-                  <li onClick={onClaim}>Claim</li>
-                  <li id="danger" onClick={onDelete}>
+                  <li onClick={() => menuOptionClicked(onEdit)}>Edit</li>
+                  <li onClick={() => menuOptionClicked(onClaim)}>Claim</li>
+                  <li id="danger" onClick={() => menuOptionClicked(onDelete)}>
                     Delete
                   </li>
                 </ul>

--- a/frontend/src/components/ListItem/ListItem.js
+++ b/frontend/src/components/ListItem/ListItem.js
@@ -3,7 +3,7 @@ import { BsPencilSquare } from "react-icons/bs";
 import { ListGroupItem, Button } from "react-bootstrap";
 
 const ListItem = (props) => {
-  const { item, onEdit } = props;
+  const { item, onEdit, onClaim } = props;
 
   return (
     <ListGroupItem>
@@ -17,13 +17,7 @@ const ListItem = (props) => {
 
         <div>
           {item.claimedBy === undefined || item.claimedBy.length === 0 ? (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                console.log(`Claim button clicked for ${item.name}`);
-              }}
-            >
+            <Button variant="secondary" size="sm" onClick={onClaim}>
               Claim
             </Button>
           ) : (

--- a/frontend/src/routes/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute.js
@@ -24,6 +24,7 @@ class RoomRoute extends Component {
   }
 
   componentDidMount() {
+    window.localStorage.clear();
     this.loadData();
     this.setupEventListeners();
 
@@ -138,7 +139,7 @@ class RoomRoute extends Component {
       });
     }
   };
-  
+
   // Called when delete button is clicked for an item in the list
   deleteItem = (item) => {
     console.log("Delete button clicked for item: ", item);
@@ -227,8 +228,8 @@ class RoomRoute extends Component {
               <Modal.Title>Choose Your Name</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-              Before you can claim items, you must choose a name so that other
-              users know who you are.
+              Choose a name so that other people in the room know who you are.
+              This data will only be stored locally in your browser.
               <hr />
               <ChooseNameForm onSubmit={this.editName} />
             </Modal.Body>


### PR DESCRIPTION
If a name is not in LocalStorage (depending on how much client-side data we want to store, we could switch this to an object but right now it is just the "name" field.) then it will display a modal asking for their name. From now on, it will use that name when claiming items. If no name is given (or the name is empty) then this modal will show up again once you try to claim an item. 

This could possibly be removed if we decide to add accounts to the mix (if we can find an CAS library for Go then this could be pretty easy..?), but it works pretty well for now. 