### PR TITLE
Editor tweaks

### DIFF
--- a/frontend/src/components/RoomCanvas/RoomCanvas.js
+++ b/frontend/src/components/RoomCanvas/RoomCanvas.js
@@ -79,6 +79,7 @@ class RoomCanvas extends Component {
       onObjectUpdated: this.editorItemUpdated,
       onObjectSelected: this.editorItemSelected,
       selectedObjectID: undefined,
+      fontFamily: "Source Sans Pro",
     });
     scene.addObject(room);
 

--- a/frontend/src/room-editor/RoomEditorObject.js
+++ b/frontend/src/room-editor/RoomEditorObject.js
@@ -15,6 +15,7 @@ class RoomEditorObject extends SceneObject {
     backgroundColor,
     onObjectUpdated,
     onObjectSelected,
+    fontFamily,
   }) {
     super({
       scene: scene,
@@ -39,6 +40,8 @@ class RoomEditorObject extends SceneObject {
     this.borderColor = "#555";
     this.borderWidth = 0.07;
     this.opacity = opacity ?? 1.0;
+
+    this.fontFamily = fontFamily;
 
     this.onObjectUpdated = onObjectUpdated;
     this.onObjectSelected = onObjectSelected;
@@ -384,6 +387,7 @@ class RoomEditorObject extends SceneObject {
       snapOffset: 0.2,
       canvasLayer: this.canvasLayer,
       movementLocked: movementLocked ?? false,
+      fontFamily: this.fontFamily,
     });
     this.roomItems.add(obj.id);
     this.addChild(obj);

--- a/frontend/src/room-editor/RoomEditorObject.js
+++ b/frontend/src/room-editor/RoomEditorObject.js
@@ -75,6 +75,8 @@ class RoomEditorObject extends SceneObject {
     this.floorGrid = floorGrid;
 
     this.selectedObject = null;
+    // Keeps track of maximum z index so far so when an object is selected it can be given the highest z value. There may be a better way of doing this
+    this._maxZIndex = 0;
 
     this.objectColors = ["#0043E0", "#f28a00", "#C400E0", "#7EE016", "#0BE07B"];
     this.objectColorCounter = 0;
@@ -273,9 +275,11 @@ class RoomEditorObject extends SceneObject {
 
   // Mouse callbacks that are passed to mouse controller
   onMouseDown(position) {
-    // Get the object indices that were under the click and sort them in descending order so that the one on top is selected
+    // Get the object indices that were under the click and sort in order of descending zIndex so that highest object takes priority
     const clicked = this._getChildrenIndicesAtPosition(position).sort(
-      (a, b) => b - a
+      (a, b) => {
+        return this.children[b].zIndex - this.children[a].zIndex;
+      }
     );
     if (clicked.length > 0) {
       for (let i = 0; i < clicked.length; i++) {
@@ -289,8 +293,8 @@ class RoomEditorObject extends SceneObject {
             }
             obj.selected = true;
             this.selectedObject = obj;
-            // Move the selected object to the back of the children array so its drawn last (on top)
-            this.children.push(this.children.splice(clicked[i], 1)[0]);
+            obj.zIndex = ++this._maxZIndex;
+
             this.onObjectSelected(obj);
           }
           return;
@@ -380,7 +384,7 @@ class RoomEditorObject extends SceneObject {
       rotation: rotation ?? 0,
       size: new Vector2(width ?? 1, height ?? 1),
       color: color,
-      opacity: 0.5,
+      opacity: 0.65,
       nameText: name ?? "New Item",
       staticObject: false,
       snapPosition: false,

--- a/frontend/src/room-editor/RoomRectObject.js
+++ b/frontend/src/room-editor/RoomRectObject.js
@@ -112,10 +112,10 @@ class RoomRectObject extends SceneObject {
       bbox.p2.x -= offset;
       bbox.p2.y -= offset;
       this.outOfBounds = false;
-      if (this.parent._offsetPoints) {
-        for (let i = 0; i < this.parent._offsetPoints.length - 1; i++) {
-          const v1 = this.parent._offsetPoints[i];
-          const v2 = this.parent._offsetPoints[i + 1];
+      if (this.parent.boundaryPoints) {
+        for (let i = 0; i < this.parent.boundaryPoints.length - 1; i++) {
+          const v1 = this.parent.boundaryPoints[i];
+          const v2 = this.parent.boundaryPoints[i + 1];
           if (Collisions.segmentIntersectsRect(v1, v2, bbox.p1, bbox.p2)) {
             this.outOfBounds = true;
           }

--- a/frontend/src/room-editor/RoomRectObject.js
+++ b/frontend/src/room-editor/RoomRectObject.js
@@ -17,6 +17,7 @@ class RoomRectObject extends SceneObject {
     snapOffset,
     canvasLayer,
     movementLocked,
+    fontFamily,
   }) {
     super({
       scene: scene,
@@ -35,6 +36,7 @@ class RoomRectObject extends SceneObject {
     this.opacity = opacity ?? 1.0;
 
     this.nameText = nameText;
+    this.fontFamily = fontFamily;
 
     this.outOfBounds = false;
     this.outOfBoundsColor = "#ff0000";
@@ -160,15 +162,17 @@ class RoomRectObject extends SceneObject {
     // Draw text on top of object - For some reason the context using the transformation matrix seems to draw the text differently on firefox and chrome resulting in it being offset. So its being drawn by manually scaling the necessary values.
     const globalPos = this.localToGlobalPoint(this.position);
 
-    const fontSize = 0.28;
+    const fontSize = 0.35;
     this._setContextTextStyle(ctx, fontSize);
-    const lineOffset = 0.18 * this.parent.scale.x;
+    const lineOffset = 0.2 * this.parent.scale.x;
     const fitNameText = this._getEditedText(ctx, this.nameText);
     const fitDimensionsText = this._getEditedText(
       ctx,
       `${this.size.x}' x ${this.size.y}'`
     );
-    ctx.font = `bold ${fontSize * this.parent.scale.x}px sans-serif`;
+    ctx.font = `700 ${fontSize * this.parent.scale.x}px ${
+      this.fontFamily
+    }, sans-serif`;
 
     ctx.fillText(fitNameText, globalPos.x, globalPos.y - lineOffset);
 

--- a/frontend/src/room-editor/SceneController.js
+++ b/frontend/src/room-editor/SceneController.js
@@ -12,6 +12,8 @@ class SceneController {
     this.backgroundColor = "#fff";
 
     this.objects = new Map();
+    // Array which will contain references to the objects sorted by their Z-index values
+    this._objectDrawOrder = [];
 
     this._lastFrameTime = undefined;
     this.deltaTime = undefined; // Time since last frame
@@ -48,6 +50,7 @@ class SceneController {
 
   addObject(obj) {
     this.objects.set(obj.id, obj);
+    this._updateDrawOrder();
   }
 
   removeObject(obj) {
@@ -56,11 +59,12 @@ class SceneController {
       obj.children[i].parent = null;
     }
     obj.parent.removeChild(obj);
+    this._updateDrawOrder();
   }
 
   update() {
-    for (let obj of this.objects.values()) {
-      obj.update();
+    for (let i = 0; i < this._objectDrawOrder.length; i++) {
+      this._objectDrawOrder[i].update();
     }
   }
 
@@ -78,11 +82,17 @@ class SceneController {
     // Clear canvas
     this._clearForegroundCanvases(this.ctx);
 
-    for (let obj of this.objects.values()) {
-      obj.draw();
+    for (let i = 0; i < this._objectDrawOrder.length; i++) {
+      this._objectDrawOrder[i].draw();
     }
 
     this._updateBackground = false;
+  }
+
+  _updateDrawOrder() {
+    this._objectDrawOrder = [...this.objects.values()].sort((a, b) => {
+      return a._zIndex - b._zIndex;
+    });
   }
 
   _clearForegroundCanvases(contexts) {

--- a/frontend/src/room-editor/SceneObject.js
+++ b/frontend/src/room-editor/SceneObject.js
@@ -11,6 +11,7 @@ class SceneObject {
     origin,
     canvasLayer,
     staticObject,
+    zIndex,
   }) {
     this.scene = scene;
     this.id = id ?? scene.idCounter++;
@@ -22,6 +23,7 @@ class SceneObject {
     this.parent = null;
     this._children = [];
     this._size = size;
+    this._zIndex = zIndex ?? 0;
     this.canvasLayer = canvasLayer ?? 0;
     if (canvasLayer === 0) {
       this.scene._updateBackground = true;
@@ -84,6 +86,9 @@ class SceneObject {
   get size() {
     return this._size;
   }
+  get zIndex() {
+    return this._zIndex;
+  }
 
   get children() {
     return this._children;
@@ -111,6 +116,10 @@ class SceneObject {
   set size(vector) {
     this._size = vector;
     this._updateTransform();
+  }
+  set zIndex(val) {
+    this._zIndex = val;
+    this.scene._updateDrawOrder();
   }
 
   rotateBy(degs) {


### PR DESCRIPTION
Fixes and improves some minor stuff in the editor:
- Adds font ability to set fontFamily for room editor. Sets it to "Source Sans Pro"
- Adds a draw order system (z-index) to SceneObjects/SceneController
- Fixes selection behavior for objects in editor. Now when selected, an object is moved to end of the draw order (drawn on top) and when clicking on stacked objects, selection prioritizes highest zIndex (topmost object)
- Fixes minor issues with edge collisions not checking correct points
- Removed unused boundaryBoxes code from RoomEditorObject