### PR TITLE
Add item duplication

### DIFF
--- a/frontend/src/components/DormItemList/DormItemList.js
+++ b/frontend/src/components/DormItemList/DormItemList.js
@@ -7,6 +7,7 @@ const DormItemList = (props) => {
     items,
     selectedItemID,
     onEditItem,
+    onDuplicateItem,
     onClaimItem,
     onDeleteItem,
     onToggleEditorVisibility,
@@ -27,6 +28,7 @@ const DormItemList = (props) => {
                 onEdit={() => onEditItem(item)}
                 onClaim={() => onClaimItem(item)}
                 onDelete={() => onDeleteItem(item)}
+                onDuplicate={() => onDuplicateItem(item)}
                 onToggleEditorVisibility={() => onToggleEditorVisibility(item)}
               />
             );

--- a/frontend/src/components/ListItem/ListItem.js
+++ b/frontend/src/components/ListItem/ListItem.js
@@ -7,6 +7,7 @@ import {
   BsPersonDash,
   BsEye,
   BsEyeSlash,
+  BsFiles,
 } from "react-icons/bs";
 import { usePopper } from "react-popper";
 import { RoomContext } from "../../routes/RoomRoute/RoomContext";
@@ -20,6 +21,7 @@ const ListItem = (props) => {
     onEdit,
     onClaim,
     onDelete,
+    onDuplicate,
     onToggleEditorVisibility,
     className,
   } = props;
@@ -105,6 +107,10 @@ const ListItem = (props) => {
             <li id="top" onClick={() => menuOptionClicked(onEdit)}>
               <BsPencil />
               Edit
+            </li>
+            <li id="top" onClick={() => menuOptionClicked(onDuplicate)}>
+              <BsFiles />
+              Duplicate
             </li>
             <li onClick={() => menuOptionClicked(onClaim)}>
               {item.claimedBy === userName ? (

--- a/frontend/src/components/ListItem/ListItem.js
+++ b/frontend/src/components/ListItem/ListItem.js
@@ -104,11 +104,11 @@ const ListItem = (props) => {
           {...attributes.popper}
         >
           <ul>
-            <li id="top" onClick={() => menuOptionClicked(onEdit)}>
+            <li onClick={() => menuOptionClicked(onEdit)}>
               <BsPencil />
               Edit
             </li>
-            <li id="top" onClick={() => menuOptionClicked(onDuplicate)}>
+            <li onClick={() => menuOptionClicked(onDuplicate)}>
               <BsFiles />
               Duplicate
             </li>

--- a/frontend/src/routes/RoomRoute/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute/RoomRoute.js
@@ -173,6 +173,10 @@ export const RoomRoute = () => {
     [updateItems, toggleModal]
   );
 
+  const onClickDuplicateItemButton = useCallback((item) => addItem(item), [
+    addItem,
+  ]);
+
   const onClickClaimItemButton = useCallback(
     (item) =>
       updateItems([
@@ -296,6 +300,7 @@ export const RoomRoute = () => {
               items={items}
               selectedItemID={selectedItemID}
               onEditItem={onClickEditItemButton}
+              onDuplicateItem={onClickDuplicateItemButton}
               onClaimItem={onClickClaimItemButton}
               onDeleteItem={deleteItem}
               onToggleEditorVisibility={onToggleItemEditorVisibility}


### PR DESCRIPTION
A quick change that allows items to be duplicated. This makes it significantly easier to create rooms, as you can create items once and then just clone them. It depends on the same logic that is used for creating items, so there shouldn't be too many issues here (unless some of the frontend logic is messed up.) Right now the existing item object is passed to the `addItem` function, which seems fine since the unique stuff (like the ID) is generated on the server anyways.

<img width="504" alt="Screen Shot 2021-01-10 at 3 46 55 PM" src="https://user-images.githubusercontent.com/8661089/104134983-1edf1d80-535b-11eb-9f48-3ff89ffdd01f.png">
<img width="381" alt="Screen Shot 2021-01-10 at 3 47 01 PM" src="https://user-images.githubusercontent.com/8661089/104134976-1850a600-535b-11eb-9be0-be2db2ba1d7f.png">

