### PR TITLE
Ssl deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dormdesign
 .DS_Store
 .vscode/
 
+certbot/
+data/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,10 +28,10 @@ services:
       - DATABASE_ADDRESS=db:28015
     depends_on:
       - db
-  proxy:
-    build:
-      dockerfile: Dockerfile
-      context: ./nginx
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf
     ports:
       - "5500:80"
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,8 +14,8 @@ services:
       dockerfile: Dockerfile.dev
     stdin_open: true
     volumes:
-      - './frontend:/app'
-      - '/app/node_modules'
+      - "./frontend:/app"
+      - "/app/node_modules"
     environment:
       - CHOKIDAR_USEPOLLING=true
     depends_on:
@@ -33,12 +33,8 @@ services:
       dockerfile: Dockerfile
       context: ./nginx
     ports:
-      - '5500:80'
+      - "5500:80"
     depends_on:
       - frontend
       - server
       - db
-
-  
-  
-  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     restart: unless-stopped
     depends_on:
       - server
-  proxy:
+  nginx:
     # build:
     #   dockerfile: Dockerfile
     #   context: ./nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     image: rethinkdb:latest
     restart: unless-stopped
     ports:
-      - 8080:8080
       - 29015:29015
       - 28015:28015
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 29015:29015
       - 28015:28015
     volumes:
-      - "./rethinkdb_data:/data/rethinkdb_data"
+      - "./data/rethinkdb_data:/data/rethinkdb_data"
   server:
     build:
       context: ./server
@@ -26,15 +26,26 @@ services:
     depends_on:
       - server
   proxy:
-    build:
-      dockerfile: Dockerfile
-      context: ./nginx
+    # build:
+    #   dockerfile: Dockerfile
+    #   context: ./nginx
+    image: nginx:alpine
     restart: unless-stopped
     ports:
-      - '5500:80'
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
     depends_on:
       - frontend
       - server
       - db
-
-  
+    command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"''' # Reload auto-renewed ssl certificates
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'" # Check for auto-renew every 12 hours

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,6 @@ services:
     depends_on:
       - server
   nginx:
-    # build:
-    #   dockerfile: Dockerfile
-    #   context: ./nginx
     image: nginx:alpine
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/conf.d
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
     depends_on:

--- a/frontend/src/components/ListItem/ListItem.js
+++ b/frontend/src/components/ListItem/ListItem.js
@@ -35,7 +35,6 @@ const ListItem = (props) => {
     Note that this could be an issue if two users input the same userName
   */
   const { userName, setUserName } = useContext(RoomContext);
-  console.log(userName);
   const [modalProps, toggleModal] = useModal();
   const [showMenu, setShowMenu] = useState(false);
   const menuButtonRef = useRef(null);

--- a/frontend/src/controllers/SocketConnection.js
+++ b/frontend/src/controllers/SocketConnection.js
@@ -4,8 +4,9 @@ class SocketConnection {
   constructor(id, onOpen) {
     this.id = id;
     this.eventController = new EventController();
+    const protocol = window.location.protocol !== "https" ? "ws" : "wss";
     this.connection = new WebSocket(
-      `wss://${window.location.host}/ws?id=${this.id}`
+      `${protocol}://${window.location.host}/ws?id=${this.id}`
     );
     this.connection.onopen = () => {
       if (onOpen !== undefined) {

--- a/frontend/src/controllers/SocketConnection.js
+++ b/frontend/src/controllers/SocketConnection.js
@@ -4,7 +4,7 @@ class SocketConnection {
   constructor(id, onOpen) {
     this.id = id;
     this.eventController = new EventController();
-    const protocol = window.location.protocol !== "https" ? "ws" : "wss";
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
     this.connection = new WebSocket(
       `${protocol}://${window.location.host}/ws?id=${this.id}`
     );

--- a/frontend/src/controllers/SocketConnection.js
+++ b/frontend/src/controllers/SocketConnection.js
@@ -5,7 +5,7 @@ class SocketConnection {
     this.id = id;
     this.eventController = new EventController();
     this.connection = new WebSocket(
-      `ws://${window.location.host}/ws?id=${this.id}`
+      `wss://${window.location.host}/ws?id=${this.id}`
     );
     this.connection.onopen = () => {
       if (onOpen !== undefined) {

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -5,7 +5,7 @@ if ! [ -x "$(command -v docker-compose)" ]; then
   exit 1
 fi
 
-domains=(NAME_HERE)
+domains=(dormdesign.app www.dormdesign.app)
 rsa_key_size=4096
 data_path="./data/certbot"
 email="" # Adding a valid address is strongly recommended

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+  echo 'Error: docker-compose is not installed.' >&2
+  exit 1
+fi
+
+domains=(NAME_HERE)
+rsa_key_size=4096
+data_path="./data/certbot"
+email="" # Adding a valid address is strongly recommended
+staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose exec nginx nginx -s reload

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -37,6 +37,7 @@ server{
 
   location ~* /(api|ws) {
     proxy_pass http://server;
+    proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";
     proxy_set_header Host $host;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,7 +8,7 @@ upstream server{
 
 server {
   listen 80;
-  server_name NAME_HERE;    
+  server_name dormdesign.app;    
   
   location /.well-known/acme-challenge/ {
     root /var/www/certbot;
@@ -20,10 +20,10 @@ server {
 
 server{
   listen 443 ssl;
-  server_name NAME_HERE;
+  server_name dormdesign.app;
 
-  ssl_certificate /etc/letsencrypt/live/NAME_HERE/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/NAME_HERE/privkey.pem;
+  ssl_certificate /etc/letsencrypt/live/dormdesign.app/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/dormdesign.app/privkey.pem;
 
   include /etc/letsencrypt/options-ssl-nginx.conf;
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,8 +6,27 @@ upstream server{
   server server:8000;
 }
 
-server{
+server {
   listen 80;
+  server_name NAME_HERE;    
+  
+  location /.well-known/acme-challenge/ {
+    root /var/www/certbot;
+  }
+  location / {
+    return 301 https://$host$request_uri;
+  }    
+}
+
+server{
+  listen 443 ssl;
+  server_name NAME_HERE;
+
+  ssl_certificate /etc/letsencrypt/live/NAME_HERE/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/NAME_HERE/privkey.pem;
+
+  include /etc/letsencrypt/options-ssl-nginx.conf;
+  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
   location / {
     proxy_pass http://frontend;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
 upstream frontend{
   server frontend:3000;
 }
@@ -39,7 +44,7 @@ server{
     proxy_pass http://server;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "Upgrade";
+    proxy_set_header Connection $connection_upgrade;
     proxy_set_header Host $host;
   }
 }

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -1,0 +1,25 @@
+upstream frontend{
+  server frontend:3000;
+}
+
+upstream server{
+  server server:8000;
+}
+
+server{
+  listen 80;
+
+  location / {
+    proxy_pass http://frontend;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+  }
+
+  location ~* /(api|ws) {
+    proxy_pass http://server;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+  }
+}


### PR DESCRIPTION
Deployment should now work properly (and be easy to do). 

The updated steps are in the README. Basically, now we just need to run a script called `init-letsencrypt.sh` when setting up the server (so not every time the server is run, but just once), which creates the SSL certificates for dormdesign.app and www.dormdesign.app. Then, we can just start the server using docker-compose and from then on everything else (including renewal of the certificates) should be handles automatically.