### PR TITLE
Delete rooms

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -68,17 +68,24 @@ textarea {
   box-shadow: $box-shadow;
 
   @include button-background-color($color-primary);
+  &.custom-btn-outline {
+    @include button-outline-color($color-primary, $text-color-light);
+  }
 
   &.custom-btn-secondary {
-    background-color: $color-secondary;
-
     @include button-background-color($color-secondary);
   }
 
-  &.custom-btn-warning {
-    background-color: $color-danger;
-
+  &.custom-btn-danger {
     @include button-background-color($color-danger);
+  }
+
+  &.custom-btn-outline.custom-btn-secondary {
+    @include button-outline-color($color-secondary, $text-color-light);
+  }
+
+  &.custom-btn-outline.custom-btn-danger {
+    @include button-outline-color($color-danger, $text-color-light);
   }
 
   &.custom-btn-large {

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -75,6 +75,12 @@ textarea {
     @include button-background-color($color-secondary);
   }
 
+  &.custom-btn-warning {
+    background-color: $color-danger;
+
+    @include button-background-color($color-danger);
+  }
+
   &.custom-btn-large {
     padding: 10px 18px;
     font-size: $btn-font-size-large;

--- a/frontend/src/components/ConfirmationButton/ConfirmationButton.js
+++ b/frontend/src/components/ConfirmationButton/ConfirmationButton.js
@@ -1,19 +1,28 @@
 import React, { useState } from "react";
 
 export default function ConfirmationButton(props) {
-  const [confirmed, setConfirmed] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
 
-  const onConfirm = () => {
-    if (confirmed) props.onConfirm();
-    else setConfirmed(true);
-  };
+  const { label, onConfirm } = props;
 
   return (
-    <button
-      className={`${props.className} custom-btn custom-btn-outline custom-btn-danger w-100`}
-      onClick={onConfirm}
-    >
-      {props.children}
-    </button>
+    <div className="d-flex flex-row flex-nowrap align-items-center">
+      {showConfirm ? (
+        <button
+          className="custom-btn custom-btn-danger mr-2"
+          onClick={onConfirm}
+        >
+          Confirm
+        </button>
+      ) : null}
+      <button
+        className={`custom-btn custom-btn-outline ${
+          showConfirm ? "custom-btn-secondary" : "custom-btn-danger"
+        }`}
+        onClick={() => setShowConfirm(!showConfirm)}
+      >
+        {showConfirm ? "Cancel" : label}
+      </button>
+    </div>
   );
 }

--- a/frontend/src/components/ConfirmationButton/ConfirmationButton.js
+++ b/frontend/src/components/ConfirmationButton/ConfirmationButton.js
@@ -1,21 +1,19 @@
-import React, { useState } from 'react'
+import React, { useState } from "react";
 
 export default function ConfirmationButton(props) {
-    const [ confirmed, setConfirmed ] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
 
-    const onConfirm = () => {
-        if(confirmed)
-            props.onConfirm();
-        else 
-            setConfirmed(true);
-    }
+  const onConfirm = () => {
+    if (confirmed) props.onConfirm();
+    else setConfirmed(true);
+  };
 
-    return (
-        <button 
-            className="custom-btn custom-btn-warning w-100"
-          onClick={ onConfirm }
-        >
-          {props.name} { confirmed ? <>(Are You Sure?)</> : <></> }
-        </button>
-    )
+  return (
+    <button
+      className={`${props.className} custom-btn custom-btn-outline custom-btn-danger w-100`}
+      onClick={onConfirm}
+    >
+      {props.children}
+    </button>
+  );
 }

--- a/frontend/src/components/ConfirmationButton/ConfirmationButton.js
+++ b/frontend/src/components/ConfirmationButton/ConfirmationButton.js
@@ -1,0 +1,21 @@
+import React, { useState } from 'react'
+
+export default function ConfirmationButton(props) {
+    const [ confirmed, setConfirmed ] = useState(false);
+
+    const onConfirm = () => {
+        if(confirmed)
+            props.onConfirm();
+        else 
+            setConfirmed(true);
+    }
+
+    return (
+        <button 
+            className="custom-btn custom-btn-warning w-100"
+          onClick={ onConfirm }
+        >
+          {props.name} { confirmed ? <>(Are You Sure?)</> : <></> }
+        </button>
+    )
+}

--- a/frontend/src/components/SingleInputForm/SingleInputForm.js
+++ b/frontend/src/components/SingleInputForm/SingleInputForm.js
@@ -5,7 +5,14 @@ import { Form } from "react-bootstrap";
   Creates a single-line form with an input and submit buttom
 */
 const SingleInputForm = (props) => {
-  const { initialValue, submitButtonText, placeholder, maxLength } = props;
+  const {
+    initialValue,
+    submitButtonText,
+    placeholder,
+    maxLength,
+    buttonClassName,
+    mustMatch, // Text that input must match in order for submit button to be enabled
+  } = props;
   const trim = props.trim ?? false; // Whether or not to trim input text
   const allowEmptySubmit = props.allowEmptySubmit ?? false; // Whether or not to enable submitting an empty input
 
@@ -41,8 +48,11 @@ const SingleInputForm = (props) => {
           onChange={handleInputChange}
         />
         <button
-          className="custom-btn ml-2 flex-shrink-0"
-          disabled={!allowEmptySubmit && inputValue === "" ? true : false}
+          className={`${buttonClassName} custom-btn ml-2 flex-shrink-0`}
+          disabled={
+            (!allowEmptySubmit && inputValue === "" ? true : false) ||
+            (mustMatch !== undefined && inputValue !== mustMatch)
+          }
           type="submit"
         >
           {submitButtonText ?? "Save"}

--- a/frontend/src/components/modals/SettingsModal.js
+++ b/frontend/src/components/modals/SettingsModal.js
@@ -5,7 +5,6 @@ import SingleInputForm from "../SingleInputForm/SingleInputForm";
 
 const SettingsModal = (props) => {
   const [cloneIdValue, setCloneIdValue] = useState("");
-  const [snapEnabled, setSnapEnabled] = useState(true);
 
   const handleInputChange = (evt) => {
     const target = evt.target;
@@ -22,9 +21,9 @@ const SettingsModal = (props) => {
     props.onClone(cloneIdValue);
   };
 
-  const onPixelSnappedChanged = (evt) => {
-    setSnapEnabled(evt.target.checked);
-  };
+  const onDeleteRoom = (evt) => {
+    props.onDeleteRoom();
+  }
 
   return (
     <Modal show={props.show} onHide={props.onHide} centered={props.centered}>
@@ -45,27 +44,6 @@ const SettingsModal = (props) => {
         />
 
         <br />
-
-        {/*<h5>Editor Settings</h5>
-        <b>Pixel Snap</b>
-        <p style={{marginBottom: 4 + 'px'}}>
-          Limits movements to whole multiples of the pixel snap ratio. This makes it easier to line up objects and improves performance.
-        </p>
-        <Form.Group controlId="pixelSnapEnabled">
-          <Form.Check type="checkbox" checked={ snapEnabled } onChange={onPixelSnappedChanged} label={ snapEnabled ? "Enabled" : "Disabled" } />
-        </Form.Group>
-
-        <b>Pixel Snap Ratio</b>
-        <p className="mb-3">
-          Specifies how precise you want movement to be. A lower ratio will be more precise at the cost of performance,
-          while a higher ratio will have better performance at the cost of precision.
-        </p>
-        <SingleInputForm
-          initialValue={props.userName}
-          onSubmit={props.onChangeUserName}
-        />
-
-     <br /> */}
 
         <h5>Room Settings</h5>
         <b>Room Name</b>
@@ -105,6 +83,18 @@ const SettingsModal = (props) => {
             </button>
           </div>
         </Form>
+
+        <br />
+
+        <b>Delete Room</b>
+        <p>Once a room is deleted, it cannot be recovered.</p>
+        <button
+          className="custom-btn custom-btn-warning w-100"
+          onClick={ onDeleteRoom }
+        >
+          Delete Room
+        </button>
+
       </Modal.Body>
     </Modal>
   );

--- a/frontend/src/components/modals/SettingsModal.js
+++ b/frontend/src/components/modals/SettingsModal.js
@@ -6,6 +6,7 @@ import SingleInputForm from "../SingleInputForm/SingleInputForm";
 
 const SettingsModal = (props) => {
   const [cloneIdValue, setCloneIdValue] = useState("");
+  const [showConfirmDelete, setShowConfirmDelete] = useState(false);
 
   const handleInputChange = (evt) => {
     const target = evt.target;
@@ -87,9 +88,30 @@ const SettingsModal = (props) => {
 
         <br />
 
-        <b>Delete Room</b>
-        <p>Once a room is deleted, it cannot be recovered.</p>
-        <ConfirmationButton onConfirm={ onDeleteRoom } name="Delete Room" />
+        <div className="d-flex flex-row justify-content-between align-items-center">
+          <div className="mr-2">
+            <b>Delete Room</b>
+            <p>Once a room is deleted, it cannot be recovered.</p>
+          </div>
+          <div className="d-flex flex-row flex-nowrap align-items-center">
+            {showConfirmDelete ? (
+              <button
+                className="custom-btn custom-btn-danger mr-2"
+                onClick={onDeleteRoom}
+              >
+                Confirm
+              </button>
+            ) : null}
+            <button
+              className={`custom-btn custom-btn-outline ${
+                showConfirmDelete ? "custom-btn-secondary" : "custom-btn-danger"
+              }`}
+              onClick={() => setShowConfirmDelete(!showConfirmDelete)}
+            >
+              {showConfirmDelete ? "Cancel" : "Delete"}
+            </button>
+          </div>
+        </div>
       </Modal.Body>
     </Modal>
   );

--- a/frontend/src/components/modals/SettingsModal.js
+++ b/frontend/src/components/modals/SettingsModal.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Form, FormControl } from "react-bootstrap";
 import Modal from "react-bootstrap/Modal";
+import ConfirmationButton from "../ConfirmationButton/ConfirmationButton";
 import SingleInputForm from "../SingleInputForm/SingleInputForm";
 
 const SettingsModal = (props) => {
@@ -88,12 +89,7 @@ const SettingsModal = (props) => {
 
         <b>Delete Room</b>
         <p>Once a room is deleted, it cannot be recovered.</p>
-        <button
-          className="custom-btn custom-btn-warning w-100"
-          onClick={onDeleteRoom}
-        >
-          Delete Room
-        </button>
+        <ConfirmationButton onConfirm={ onDeleteRoom } name="Delete Room" />
       </Modal.Body>
     </Modal>
   );

--- a/frontend/src/components/modals/SettingsModal.js
+++ b/frontend/src/components/modals/SettingsModal.js
@@ -23,7 +23,7 @@ const SettingsModal = (props) => {
 
   const onDeleteRoom = (evt) => {
     props.onDeleteRoom();
-  }
+  };
 
   return (
     <Modal show={props.show} onHide={props.onHide} centered={props.centered}>
@@ -90,11 +90,10 @@ const SettingsModal = (props) => {
         <p>Once a room is deleted, it cannot be recovered.</p>
         <button
           className="custom-btn custom-btn-warning w-100"
-          onClick={ onDeleteRoom }
+          onClick={onDeleteRoom}
         >
           Delete Room
         </button>
-
       </Modal.Body>
     </Modal>
   );

--- a/frontend/src/components/modals/SettingsModal.js
+++ b/frontend/src/components/modals/SettingsModal.js
@@ -1,27 +1,9 @@
 import React, { useState } from "react";
-import { Form, FormControl } from "react-bootstrap";
 import Modal from "react-bootstrap/Modal";
 import ConfirmationButton from "../ConfirmationButton/ConfirmationButton";
 import SingleInputForm from "../SingleInputForm/SingleInputForm";
 
 const SettingsModal = (props) => {
-  const [cloneIdValue, setCloneIdValue] = useState("");
-  const [showConfirmDelete, setShowConfirmDelete] = useState(false);
-
-  const handleInputChange = (evt) => {
-    const target = evt.target;
-    let value = target.value;
-    const name = target.name;
-
-    if (name === "cloneIdValue") {
-      setCloneIdValue(value);
-    }
-  };
-
-  const onCloneFormSubmit = (evt) => {
-    evt.preventDefault();
-    props.onClone(cloneIdValue);
-  };
 
   const onDeleteRoom = (evt) => {
     props.onDeleteRoom();
@@ -66,25 +48,12 @@ const SettingsModal = (props) => {
           a room, changes only apply to your copy, not the original.
           <strong> This is not reversible.</strong>
         </p>
-        <Form onSubmit={onCloneFormSubmit}>
-          <div className="d-flex w-100">
-            <FormControl
-              name="cloneIdValue"
-              onChange={handleInputChange}
-              placeholder="Room Template ID"
-              aria-label="Room Template ID"
-              aria-describedby="Room Identifier"
-            />
-
-            <button
-              className="custom-btn ml-2 flex-shrink-0"
-              disabled={cloneIdValue === "" ? true : false}
-              type="submit"
-            >
-              Clone
-            </button>
-          </div>
-        </Form>
+        <SingleInputForm 
+          initialValue="" 
+          onSubmit={props.onClone} 
+          submitButtonText="Clone" 
+          placeholder="Room Template ID" 
+        />
 
         <br />
 
@@ -93,24 +62,7 @@ const SettingsModal = (props) => {
             <b>Delete Room</b>
             <p>Once a room is deleted, it cannot be recovered.</p>
           </div>
-          <div className="d-flex flex-row flex-nowrap align-items-center">
-            {showConfirmDelete ? (
-              <button
-                className="custom-btn custom-btn-danger mr-2"
-                onClick={onDeleteRoom}
-              >
-                Confirm
-              </button>
-            ) : null}
-            <button
-              className={`custom-btn custom-btn-outline ${
-                showConfirmDelete ? "custom-btn-secondary" : "custom-btn-danger"
-              }`}
-              onClick={() => setShowConfirmDelete(!showConfirmDelete)}
-            >
-              {showConfirmDelete ? "Cancel" : "Delete"}
-            </button>
-          </div>
+          <ConfirmationButton label="Delete" onConfirm={onDeleteRoom} />
         </div>
       </Modal.Body>
     </Modal>

--- a/frontend/src/context/RoomContext.js
+++ b/frontend/src/context/RoomContext.js
@@ -388,6 +388,9 @@ export const RoomProvider = ({ children }) => {
         type: RoomActions.roomDeleted,
         payload: {},
       });
+
+      // Redirect to home page
+      window.location.href = "/";
     },
     [state.socketConnection]
   );

--- a/frontend/src/context/RoomContext.js
+++ b/frontend/src/context/RoomContext.js
@@ -277,6 +277,8 @@ export const RoomProvider = ({ children }) => {
         });
 
         connection.on("roomDeleted", (data) => {
+          StorageController.removeRoomFromHistory(id);
+
           window.location.reload();
         });
       } catch (error) {
@@ -381,8 +383,6 @@ export const RoomProvider = ({ children }) => {
           id,
         },
       });
-
-      StorageController.removeRoomFromHistory(id);
 
       dispatch({
         type: RoomActions.roomDeleted,

--- a/frontend/src/context/RoomContext.js
+++ b/frontend/src/context/RoomContext.js
@@ -378,7 +378,7 @@ export const RoomProvider = ({ children }) => {
         event: "deleteRoom",
         sendResponse: true,
         data: {
-          id
+          id,
         },
       });
 
@@ -386,7 +386,7 @@ export const RoomProvider = ({ children }) => {
 
       dispatch({
         type: RoomActions.roomDeleted,
-        payload: { },
+        payload: {},
       });
     },
     [state.socketConnection]

--- a/frontend/src/context/RoomContext.js
+++ b/frontend/src/context/RoomContext.js
@@ -1,8 +1,9 @@
-import React, { useReducer, useCallback, createContext } from "react";
+import React, { createContext, useCallback, useReducer } from "react";
+
 import DataRequests from "../controllers/DataRequests";
+import DormItem from "../models/DormItem";
 import SocketConnection from "../controllers/SocketConnection";
 import StorageController from "../controllers/StorageController";
-import DormItem from "../models/DormItem";
 
 export const RoomActions = {
   connectedToRoom: "CONNECTED_TO_ROOM",
@@ -279,7 +280,7 @@ export const RoomProvider = ({ children }) => {
         connection.on("roomDeleted", (data) => {
           StorageController.removeRoomFromHistory(id);
 
-          window.location.reload();
+          window.location.href = "/"; 
         });
       } catch (error) {
         console.error("Failed to connect to room: " + error);
@@ -388,9 +389,6 @@ export const RoomProvider = ({ children }) => {
         type: RoomActions.roomDeleted,
         payload: {},
       });
-
-      // Redirect to home page
-      window.location.href = "/";
     },
     [state.socketConnection]
   );

--- a/frontend/src/controllers/StorageController.js
+++ b/frontend/src/controllers/StorageController.js
@@ -52,12 +52,24 @@ export default class StorageController {
    */
   static getRoomsFromHistory() {
     let historyData = StorageController.get("history");
+    let history = [];
 
-    if (historyData == null) historyData = "[]";
-
-    let history = JSON.parse(historyData);
+    if (historyData != null)
+      history = JSON.parse(historyData);
 
     return history;
+  }
+
+  /**
+   * Remove a room from the history by its ID. Return the original array if nothing changed.
+   * @param { string } id 
+   */
+  static removeRoomFromHistory(id) {
+    let historyData = StorageController.getRoomsFromHistory();
+
+    console.log(historyData, historyData.filter((room) => room.id !== id))
+
+    StorageController.set("history", JSON.stringify(historyData.filter((room) => room.id !== id)));
   }
 
   /**

--- a/frontend/src/controllers/StorageController.js
+++ b/frontend/src/controllers/StorageController.js
@@ -54,22 +54,27 @@ export default class StorageController {
     let historyData = StorageController.get("history");
     let history = [];
 
-    if (historyData != null)
-      history = JSON.parse(historyData);
+    if (historyData != null) history = JSON.parse(historyData);
 
     return history;
   }
 
   /**
    * Remove a room from the history by its ID. Return the original array if nothing changed.
-   * @param { string } id 
+   * @param { string } id
    */
   static removeRoomFromHistory(id) {
     let historyData = StorageController.getRoomsFromHistory();
 
-    console.log(historyData, historyData.filter((room) => room.id !== id))
+    console.log(
+      historyData,
+      historyData.filter((room) => room.id !== id)
+    );
 
-    StorageController.set("history", JSON.stringify(historyData.filter((room) => room.id !== id)));
+    StorageController.set(
+      "history",
+      JSON.stringify(historyData.filter((room) => room.id !== id))
+    );
   }
 
   /**

--- a/frontend/src/routes/HomeRoute/HomeRoute.js
+++ b/frontend/src/routes/HomeRoute/HomeRoute.js
@@ -74,7 +74,7 @@ class HomeRoute extends Component {
       <div className="recent-rooms-card">
         <h5>Recent Rooms</h5>
         <div className="recent-rooms">
-          { this.state.roomHistory.map((room, id) => (
+          {this.state.roomHistory.map((room, id) => (
             <RoomPreviewCard
               key={room.id}
               id={room.id}
@@ -115,7 +115,7 @@ class HomeRoute extends Component {
               </button>
             </div>
             <div className="recent-rooms-container">
-              { this.renderExistingRooms() }
+              {this.renderExistingRooms()}
             </div>
           </div>
         </div>

--- a/frontend/src/routes/HomeRoute/HomeRoute.js
+++ b/frontend/src/routes/HomeRoute/HomeRoute.js
@@ -74,7 +74,7 @@ class HomeRoute extends Component {
       <div className="recent-rooms-card">
         <h5>Recent Rooms</h5>
         <div className="recent-rooms">
-          {this.state.roomHistory.map((room, id) => (
+          { this.state.roomHistory.map((room, id) => (
             <RoomPreviewCard
               key={room.id}
               id={room.id}
@@ -115,7 +115,7 @@ class HomeRoute extends Component {
               </button>
             </div>
             <div className="recent-rooms-container">
-              {this.renderExistingRooms()}
+              { this.renderExistingRooms() }
             </div>
           </div>
         </div>

--- a/frontend/src/routes/RoomRoute/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute/RoomRoute.js
@@ -124,7 +124,7 @@ export const RoomRoute = () => {
         },
         onDeleteRoom: () => {
           deleteRoom(id);
-        }
+        },
       }),
     [
       toggleModal,

--- a/frontend/src/routes/RoomRoute/RoomRoute.js
+++ b/frontend/src/routes/RoomRoute/RoomRoute.js
@@ -28,6 +28,7 @@ export const RoomRoute = () => {
     addItem,
     updateItems,
     deleteItem,
+    deleteRoom,
     selectedItemID,
   } = useContext(RoomContext);
 
@@ -121,6 +122,9 @@ export const RoomRoute = () => {
         onChangeRoomName: (name) => {
           updateRoomName(id, name);
         },
+        onDeleteRoom: () => {
+          deleteRoom(id);
+        }
       }),
     [
       toggleModal,

--- a/frontend/src/styles/variables.scss
+++ b/frontend/src/styles/variables.scss
@@ -28,16 +28,34 @@ $navbar-height: 56px;
 $footer-height: 50px;
 $footer-text-color: $text-color-dark;
 
-@mixin button-background-color($background-color) {
-  background-color: $background-color;
+@mixin button-background-color($color) {
+  background-color: $color;
   transition: background-color 0.2s ease;
   &:hover {
-    background-color: darken($background-color, 10%);
+    background-color: darken($color, 10%);
   }
 
   &:disabled {
-    background-color: lighten($background-color, 20%);
+    background-color: lighten($color, 20%);
     box-shadow: none;
+    cursor: default;
+  }
+}
+
+@mixin button-outline-color($color, $text-color) {
+  background-color: transparent;
+  border: 1px solid $color;
+  color: $color;
+  transition: all 0.2s ease;
+  box-shadow: none;
+
+  &:hover {
+    background-color: $color;
+    color: $text-color;
+  }
+
+  &:disabled {
+    color: lighten($color, 20%);
     cursor: default;
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "prettier:frontend": "prettier ./frontend/src --write",
     "prettier:server": "prettier ./server --write",
-    "dev": "docker-compose -f docker-compose.dev.yml up --build"
+    "dev": "docker-compose -f docker-compose.dev.yml up --build",
+    "prepare": "husky install"
   },
   "lint-staged": {
     "server/*.{js,jsx,ts,tsx,json,css,scss,md}": [

--- a/server/hub.js
+++ b/server/hub.js
@@ -266,6 +266,17 @@ Hub.updateRoomName = async function ({ socket, roomID, data, sendResponse }) {
   });
 };
 
+Hub.deleteRoom = async function ({ socket, roomID, sendResponse }) {
+  console.log(chalk.greenBright(`Deleting room with roomID ${roomID}`));
+
+  Room.delete(roomID);
+
+  Hub.send(socket.id, roomID, sendResponse, {
+    event: "roomDeleted",
+    data: {},
+  });
+};
+
 /*
   Called every PONG_TIME milliseconds. This is to check if
   every socket is still alive. If not, then remove the client.
@@ -356,6 +367,7 @@ Hub.setup = function (sockets) {
   Hub.events.addListener("deleteItem", Hub.deleteItem);
   Hub.events.addListener("updateLayout", Hub.updateLayout);
   Hub.events.addListener("cloneRoom", Hub.cloneRoom);
+  Hub.events.addListener("deleteRoom", Hub.deleteRoom);
   Hub.events.addListener("updateRoomName", Hub.updateRoomName);
 
   sockets.on("connection", Hub.onConnection);

--- a/server/models/room.model.js
+++ b/server/models/room.model.js
@@ -44,6 +44,22 @@ Room.create = async function (name) {
   return room;
 };
 
+Room.delete = async function (id) {
+  const res = await rethinkdb
+    .db("dd_data")
+    .table("rooms")
+    .get(id)
+    .delete()
+    .run(database.connection);
+
+  console.log(id);
+
+  if (res === null) {
+    console.error("Could not delete room.");
+    return null;
+  }
+}
+
 /**
  * Get the JSON data from a room at an ID
  * @param { string } id

--- a/server/models/room.model.js
+++ b/server/models/room.model.js
@@ -58,7 +58,7 @@ Room.delete = async function (id) {
     console.error("Could not delete room.");
     return null;
   }
-}
+};
 
 /**
  * Get the JSON data from a room at an ID

--- a/server/models/room.model.js
+++ b/server/models/room.model.js
@@ -52,8 +52,6 @@ Room.delete = async function (id) {
     .delete()
     .run(database.connection);
 
-  console.log(id);
-
   if (res === null) {
     console.error("Could not delete room.");
     return null;


### PR DESCRIPTION
This PR adds functionality for deleting rooms from the settings menu. Once you click on settings and scroll down, you should see a red button. Clicking this button will delete the room and refresh the window for every client. These changes will also be reflected in the room history panel on the home page.

To improve the user experience, maybe instead of refreshing the page it could redirect to the home page? Also, asking if they meant to delete the page would be nice. 