### PR TITLE
Add preview caching

### DIFF
--- a/server/models/preview.model.js
+++ b/server/models/preview.model.js
@@ -1,0 +1,24 @@
+const { client } = require("../cache");
+const PreviewRenderer = require("../services/preview-renderer");
+
+let Preview = {};
+
+Preview.CACHE_EXPIRATION = 60 * 60 * 48;
+
+Preview.get = async function(room)
+{
+    const id = room.id;
+
+	let previewUrl = await client.get(`${id}:preview`);
+	
+	// doesn't exist in the cache, load it in...
+    if(previewUrl === null)
+    {
+        previewUrl = PreviewRenderer.generatePreview(room);
+        await client.set(`${id}:preview`, previewUrl, 'EX', Preview.CACHE_EXPIRATION);
+    }
+
+    return previewUrl;
+}
+
+module.exports = Preview;

--- a/server/routes/preview.js
+++ b/server/routes/preview.js
@@ -1,5 +1,6 @@
 const { Router } = require("express");
 const Room = require("../models/room.model");
+const Preview = require("../models/preview.model");
 const PreviewRenderer = require("../services/preview-renderer");
 
 let router = Router();
@@ -16,7 +17,7 @@ router.get("/", async (req, res) => {
   if (!room) {
     res.json({ message: "Invalid room ID." });
   } else {
-    const previewUrl = PreviewRenderer.generatePreview(room);
+    let previewUrl = await Preview.get(room);
 
     res.json({
       url: previewUrl,


### PR DESCRIPTION
Previews will be cached in the cache (with an expiration date set for 48 hours) so that we can avoid unnecessary re-renders.