### PR TITLE
Fixes more instances of large icons on safari. Also fixes button 'wiggle' issue.

### DIFF
--- a/frontend/src/components/IconButton/IconButton.scss
+++ b/frontend/src/components/IconButton/IconButton.scss
@@ -9,4 +9,19 @@
     width: 100%;
     height: 100%;
   }
+
+  svg {
+    /* 
+      Forces transformations to use hardware acceleration.
+      https://blog.teamtreehouse.com/increase-your-sites-performance-with-hardware-accelerated-css
+
+      The reason this is here is because on some browsers (e.g. Safari) certain transformations (such as scale on hover) cause
+      the element to "wiggle" for some reason. This seems to have fixed that issue.
+    */
+    -webkit-transform: translateZ(0);
+    -moz-transform: translateZ(0);
+    -ms-transform: translateZ(0);
+    -o-transform: translateZ(0);
+    transform: translateZ(0);
+  }
 }

--- a/frontend/src/components/ListItem/ListItem.scss
+++ b/frontend/src/components/ListItem/ListItem.scss
@@ -1,6 +1,7 @@
 @import "../../styles/variables.scss";
 
 .item-menu-button {
+  max-width: 2.2rem;
   color: $text-color-dark;
   transition: transform 0.2s;
 
@@ -87,9 +88,9 @@
       border-bottom-color: $border-color;
 
       svg {
-        font-size: 0.8em;
+        max-width: 1.5rem;
         margin: auto 0;
-        margin-right: 0.75em;
+        margin-right: 0.6em;
       }
 
       &.color-danger {


### PR DESCRIPTION
I missed some of the large icons on safari (in this case it was the ListItem "..." button and the dropdown menu buttons). Hopefully now I've got them all.

I also fixed another issue on Safari (it might also show up on other browsers, but I haven't checked) that had been bugging me for awhile, where buttons that were scaled up on hover (e.g. the ListItem "..." button) would "wiggle" a little bit. Turns out one fix for this issue (found here: https://stackoverflow.com/questions/16208851/images-wiggles-when-hover-scale-effect/16209237) is to apply a 3D transform that does nothing, forcing the page to render the CSS using the GPU. So I applied this to all IconButtons and it seems like it worked. Definitely a hacky solution though.