### PR TITLE
Fix unknown route

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import React from "react";
 import { RoomProvider } from "./context/RoomStore";
 import { RoomRoute } from "./routes/RoomRoute/RoomRoute";
 import SceneTestingRoute from "./routes/SceneTestingRoute/SceneTestingRoute";
+import { UnknownRoute } from "./routes/UnknownRoute/UnknownRoute";
 
 const App = () => {
   return (
@@ -39,6 +40,7 @@ const MainRoutes = () => (
         </RoomProvider>
       </Route>
       <Route exact path="/scene-test" component={SceneTestingRoute} />
+      <Route path="*" exact={true} component={UnknownRoute} />
     </Switch>
   </div>
 );

--- a/frontend/src/routes/HomeRoute/HomeRoute.js
+++ b/frontend/src/routes/HomeRoute/HomeRoute.js
@@ -83,7 +83,7 @@ class HomeRoute extends Component {
       // Preview might not be loaded yet, if not just pass an empty URI ("")
       const preview = this.state.roomPreviews[id];
 
-      if(preview == null) {
+      if (preview == null) {
         console.error(`Room (${room.id}) could not render a preview.`);
       }
 

--- a/frontend/src/routes/UnknownRoute/UnknownRoute.js
+++ b/frontend/src/routes/UnknownRoute/UnknownRoute.js
@@ -3,7 +3,7 @@ import "./UnknownRoute.scss";
 
 export const UnknownRoute = () => {
   return (
-    <div className="content-wrapper">
+    <div className="unknown-wrapper">
       <div className="unknown-container">
         <h1 className="unknown_title">404</h1>
 

--- a/frontend/src/routes/UnknownRoute/UnknownRoute.js
+++ b/frontend/src/routes/UnknownRoute/UnknownRoute.js
@@ -1,0 +1,18 @@
+import { Link } from "react-router-dom";
+import "./UnknownRoute.scss";
+
+export const UnknownRoute = () => {
+    return (
+        <div className="content-wrapper">
+            <div className="unknown-container">
+                <h1 className="unknown_title">
+                    404
+                </h1>
+
+                <p className="unknown_desc">
+                    Unfortunately, we could not find the route that you were looking for. <Link to="/">Return to the home page?</Link>
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/routes/UnknownRoute/UnknownRoute.js
+++ b/frontend/src/routes/UnknownRoute/UnknownRoute.js
@@ -8,8 +8,7 @@ export const UnknownRoute = () => {
         <h1 className="unknown_title">404</h1>
 
         <p className="unknown_desc">
-          Unfortunately, we could not find the route that you were looking for.{" "}
-          <Link to="/">Return to the home page?</Link>
+          Unfortunately, we could not find the route that you were looking for. <Link to="/">Return to the home page?</Link>
         </p>
       </div>
     </div>

--- a/frontend/src/routes/UnknownRoute/UnknownRoute.js
+++ b/frontend/src/routes/UnknownRoute/UnknownRoute.js
@@ -2,17 +2,16 @@ import { Link } from "react-router-dom";
 import "./UnknownRoute.scss";
 
 export const UnknownRoute = () => {
-    return (
-        <div className="content-wrapper">
-            <div className="unknown-container">
-                <h1 className="unknown_title">
-                    404
-                </h1>
+  return (
+    <div className="content-wrapper">
+      <div className="unknown-container">
+        <h1 className="unknown_title">404</h1>
 
-                <p className="unknown_desc">
-                    Unfortunately, we could not find the route that you were looking for. <Link to="/">Return to the home page?</Link>
-                </p>
-            </div>
-        </div>
-    );
-}
+        <p className="unknown_desc">
+          Unfortunately, we could not find the route that you were looking for.{" "}
+          <Link to="/">Return to the home page?</Link>
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/routes/UnknownRoute/UnknownRoute.scss
+++ b/frontend/src/routes/UnknownRoute/UnknownRoute.scss
@@ -1,11 +1,16 @@
+.unknown-wrapper {
+    max-width: 100%;
+    margin: 7.5vh auto 0 auto;
+}
+
 .unknown-container {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
+  grid-template-columns: 1fr;
+  grid-template-rows: max-content;
   gap: 0px 0px;
   grid-template-areas:
-    "unknown_title unknown_title unknown_title"
-    "unknown_desc unknown_desc unknown_desc";
+    "unknown_title"
+    "unknown_desc";
 }
 
 .unknown_title {

--- a/frontend/src/routes/UnknownRoute/UnknownRoute.scss
+++ b/frontend/src/routes/UnknownRoute/UnknownRoute.scss
@@ -1,0 +1,22 @@
+
+
+.unknown-container {
+    display: grid; 
+    grid-template-columns: 1fr 1fr 1fr; 
+    grid-template-rows: 1fr 1fr; 
+    gap: 0px 0px; 
+    grid-template-areas: 
+      "unknown_title unknown_title unknown_title"
+      "unknown_desc unknown_desc unknown_desc"; 
+}
+
+.unknown_title { 
+    grid-area: unknown_title; 
+    justify-content: center;
+    text-align: center;
+}
+.unknown_desc { 
+    grid-area: unknown_desc;
+    justify-content: center;
+    text-align: center;
+}

--- a/frontend/src/routes/UnknownRoute/UnknownRoute.scss
+++ b/frontend/src/routes/UnknownRoute/UnknownRoute.scss
@@ -1,22 +1,20 @@
-
-
 .unknown-container {
-    display: grid; 
-    grid-template-columns: 1fr 1fr 1fr; 
-    grid-template-rows: 1fr 1fr; 
-    gap: 0px 0px; 
-    grid-template-areas: 
-      "unknown_title unknown_title unknown_title"
-      "unknown_desc unknown_desc unknown_desc"; 
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 0px 0px;
+  grid-template-areas:
+    "unknown_title unknown_title unknown_title"
+    "unknown_desc unknown_desc unknown_desc";
 }
 
-.unknown_title { 
-    grid-area: unknown_title; 
-    justify-content: center;
-    text-align: center;
+.unknown_title {
+  grid-area: unknown_title;
+  justify-content: center;
+  text-align: center;
 }
-.unknown_desc { 
-    grid-area: unknown_desc;
-    justify-content: center;
-    text-align: center;
+.unknown_desc {
+  grid-area: unknown_desc;
+  justify-content: center;
+  text-align: center;
 }


### PR DESCRIPTION
This PR essentially adds a 404 page. Previously we weren't handling unknown routes so it would just default to a blank page. As a result, I added a "catch all" route so that all unknown routes default to a 404 page. The 404 page simply displays 404, a brief description as to what happened (we could randomize these messages to add more "spunk" but for now it is fine), and a link to the home page. The styling could use some work, but it gets the job done. 

<img width="1660" alt="Screen Shot 2021-10-27 at 11 25 53 PM" src="https://user-images.githubusercontent.com/8661089/139181188-3f6e741b-f0c9-4302-a7ac-643977c4b218.png">
 