### PR TITLE
Reworked footer styling

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,13 +17,11 @@ const App = () => {
   return (
     <IconContext.Provider value={{ size: "1.6em" }}>
       <Router>
-        <div className="main-content-container offset-from-footer">
-          <Switch>
-            <Route exact path="/" component={HomeRoute} />
-            <Route component={MainRoutes} />
-          </Switch>
-          <Footer />
-        </div>
+        <Switch>
+          <Route exact path="/" component={HomeRoute} />
+          <Route component={MainRoutes} />
+        </Switch>
+        <Footer />
       </Router>
     </IconContext.Provider>
   );

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -35,11 +35,6 @@ textarea {
   font-family: "Arvo", serif;
 }
 
-.main-content-container {
-  height: 100vh;
-  overflow: hidden;
-}
-
 .offset-from-navbar {
   padding-top: $navbar-height; /* Offsets content of page from navbar (which is fixed to top) */
 }

--- a/frontend/src/components/Footer/Footer.scss
+++ b/frontend/src/components/Footer/Footer.scss
@@ -1,12 +1,6 @@
 @import "../../styles/variables.scss";
 
 .footer {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 20;
-
   padding: 5px;
 
   display: flex;


### PR DESCRIPTION
Un-fixed footer from the bottom of the page. Now the footer will just be appended to the bottom (so pages with scrolling enabled should work properly).