### PR TITLE
Added edge lengths and tooltips to editor

### DIFF
--- a/frontend/src/components/RoomEditor/BoundsToolbar.js
+++ b/frontend/src/components/RoomEditor/BoundsToolbar.js
@@ -52,6 +52,7 @@ export default function BoundsToolbar({
         </div>
         <button
           className="room-editor-point-delete-btn"
+          title="Delete Point"
           onClick={onClickDeleteSelectedPoint}
           disabled={!canDeleteSelectedPoint}
         >

--- a/frontend/src/components/RoomEditor/ItemToolbar.js
+++ b/frontend/src/components/RoomEditor/ItemToolbar.js
@@ -4,18 +4,14 @@ import IconButton from "../IconButton/IconButton";
 import React from "react";
 import { RiClockwiseLine } from "react-icons/ri";
 
-export default function ItemToolbar({
-  lockSelectedItem,
-  rotateSelectedItem,
-  selectedItemID,
-  locked,
-}) {
+export default function ItemToolbar({ lockSelectedItem, rotateSelectedItem, hidden, locked }) {
   return (
     <>
       <IconButton
         className="room-editor-toolbar-btn"
         onClick={lockSelectedItem}
-        data-hidden={selectedItemID === null ? "true" : "false"}
+        title="Lock/Unlock item"
+        data-hidden={hidden ? "true" : "false"}
       >
         {locked ? <BiLockAlt /> : <BiLockOpenAlt />}
       </IconButton>
@@ -23,7 +19,8 @@ export default function ItemToolbar({
         className="room-editor-toolbar-btn"
         onClick={rotateSelectedItem}
         disabled={locked}
-        data-hidden={selectedItemID === null ? "true" : "false"}
+        title="Rotate item"
+        data-hidden={hidden ? "true" : "false"}
       >
         <RiClockwiseLine />
       </IconButton>

--- a/frontend/src/components/RoomEditor/RoomEditor.js
+++ b/frontend/src/components/RoomEditor/RoomEditor.js
@@ -1,7 +1,8 @@
 import "./RoomEditor.scss";
 
-import { BiMinus, BiPlus } from "react-icons/bi";
-import { BsBoundingBox, BsCheck, BsX } from "react-icons/bs";
+import { BiMinus, BiPlus, BiSelection } from "react-icons/bi";
+import { BsCheck, BsX } from "react-icons/bs";
+import { RiRulerFill, RiRulerLine } from "react-icons/ri";
 import React, { useEffect, useRef, useState } from "react";
 import {
   clearEditorActionQueue,
@@ -53,6 +54,8 @@ function RoomEditor() {
   const [editingBounds, setEditingBounds] = useState(false);
   const [selectedPointX, setSelectedPointX] = useState("");
   const [selectedPointY, setSelectedPointY] = useState("");
+  // Start with edge lengths true since that is the default in RoomBoundsObject
+  const [showEdgeLengths, setShowEdgeLengths] = useState(true);
 
   const scene = useRef(null);
   const room = useRef(null);
@@ -285,7 +288,7 @@ function RoomEditor() {
                 <ItemToolbar
                   lockSelectedItem={lockSelectedItem}
                   rotateSelectedItem={rotateSelectedItem}
-                  selectedItemID={selectedItemID}
+                  hidden={selectedItemID === null}
                   locked={locked}
                 />
               )
@@ -296,6 +299,7 @@ function RoomEditor() {
               <>
                 <IconButton
                   className="room-editor-toolbar-btn room-editor-toolbar-btn-success"
+                  title="Apply Changes"
                   onClick={() => {
                     toggleEditingBounds(true);
                   }}
@@ -304,6 +308,7 @@ function RoomEditor() {
                 </IconButton>
                 <IconButton
                   className="room-editor-toolbar-btn room-editor-toolbar-btn-danger"
+                  title="Cancel Changes"
                   onClick={() => {
                     toggleEditingBounds(false);
                   }}
@@ -312,15 +317,29 @@ function RoomEditor() {
                 </IconButton>
               </>
             ) : (
-              <IconButton
-                className="room-editor-toolbar-btn"
-                onClick={() => {
-                  toggleEditingBounds();
-                }}
-                style={{ padding: "9px" }}
-              >
-                <BsBoundingBox />
-              </IconButton>
+              <>
+                <IconButton
+                  className="room-editor-toolbar-btn"
+                  title="Toggle Edge Lengths"
+                  onClick={() => {
+                    if (room.current !== undefined) {
+                      room.current.bounds.edgeLengths = !showEdgeLengths;
+                      setShowEdgeLengths(!showEdgeLengths);
+                    }
+                  }}
+                >
+                  {showEdgeLengths ? <RiRulerFill /> : <RiRulerLine />}
+                </IconButton>
+                <IconButton
+                  className="room-editor-toolbar-btn"
+                  title="Edit Room Bounds"
+                  onClick={() => {
+                    toggleEditingBounds();
+                  }}
+                >
+                  <BiSelection />
+                </IconButton>
+              </>
             )}
           </div>
         </div>
@@ -329,6 +348,7 @@ function RoomEditor() {
         </div>
         <div className="room-editor-corner-controls">
           <IconButton
+            title="Zoom In"
             onClick={() => {
               if (room.current !== undefined) {
                 // Scale about the center of the canvas
@@ -342,6 +362,7 @@ function RoomEditor() {
             <BiPlus />
           </IconButton>
           <IconButton
+            title="Center View"
             onClick={() => {
               if (room.current !== undefined) {
                 room.current.centerView();
@@ -351,6 +372,7 @@ function RoomEditor() {
             <MdFilterCenterFocus />
           </IconButton>
           <IconButton
+            title="Zoom Out"
             onClick={() => {
               if (room.current !== undefined) {
                 // Scale about the center of the canvas

--- a/frontend/src/components/RoomEditor/RoomEditor.scss
+++ b/frontend/src/components/RoomEditor/RoomEditor.scss
@@ -19,6 +19,11 @@
       z-index: 3;
     }
 
+    [data-hidden="true"] {
+      box-shadow: none;
+      transform: scale(0);
+    }
+
     .room-editor-footer {
       position: absolute;
       color: $text-color-dark;
@@ -161,11 +166,6 @@
         @include button-background-color($color-primary);
 
         transition: transform 0.2s ease, background-color 0.2s ease;
-
-        &[data-hidden="true"] {
-          box-shadow: none;
-          transform: scale(0);
-        }
       }
     }
   }

--- a/frontend/src/room-editor/RoomBoundsObject.js
+++ b/frontend/src/room-editor/RoomBoundsObject.js
@@ -31,7 +31,7 @@ class RoomBoundsObject extends SceneObject {
     // Both scale and font size will affect the drawn size, but since font size can't go lower than 1px on some browsers
     // it's best to adjust scale if you want to change how large the font is drawn
     this.edgeLengthFontSize = 1;
-    this.edgeLengthScale = 0.5;
+    this.edgeLengthScale = 0.4;
     this.edgeLengthFontStyle = `bold ${this.edgeLengthFontSize}px "Source Sans Pro", sans-serif`;
 
     this.onPointsUpdated = onPointsUpdated ?? (() => {});

--- a/frontend/src/room-editor/RoomBoundsObject.js
+++ b/frontend/src/room-editor/RoomBoundsObject.js
@@ -463,7 +463,7 @@ class RoomBoundsObject extends SceneObject {
       for (let i = 0; i < this._edgeLengthPositions.length; i++) {
         const length = this._edgeLengths[i].toString();
         const pos = this._edgeLengthPositions[i];
-        ctx.fillText(length + "ft", pos.x, pos.y);
+        ctx.fillText(length + " ft", pos.x, pos.y);
       }
       ctx.globalAlpha = 1.0;
     }

--- a/frontend/src/room-editor/RoomBoundsObject.js
+++ b/frontend/src/room-editor/RoomBoundsObject.js
@@ -28,7 +28,10 @@ class RoomBoundsObject extends SceneObject {
     this._edgeLengthPositions = [];
     this.edgeLengthDistance = 0.7;
     this.edgeLengths = true;
-    this.edgeLengthFontSize = 0.35;
+    // Both scale and font size will affect the drawn size, but since font size can't go lower than 1px on some browsers
+    // it's best to adjust scale if you want to change how large the font is drawn
+    this.edgeLengthFontSize = 1;
+    this.edgeLengthScale = 0.5;
 
     this.onPointsUpdated = onPointsUpdated ?? (() => {});
     this.onPointSelected = onPointSelected ?? (() => {});
@@ -123,9 +126,10 @@ class RoomBoundsObject extends SceneObject {
 
       const norm = Vector2.normalized(new Vector2(dy, -dx));
       this._edgeLengthPositions.push(
+        // Multiply by 1/edgeLengthScale counter the scale that will be applied when the edge lengths are drawn
         new Vector2(
-          p1.x + dx / 2 + norm.x * this.edgeLengthDistance,
-          p1.y + dy / 2 + norm.y * this.edgeLengthDistance
+          (p1.x + dx / 2 + norm.x * this.edgeLengthDistance) / this.edgeLengthScale,
+          (p1.y + dy / 2 + norm.y * this.edgeLengthDistance) / this.edgeLengthScale
         )
       );
     }
@@ -460,11 +464,16 @@ class RoomBoundsObject extends SceneObject {
       ctx.font = `bold ${this.edgeLengthFontSize}px sans-serif`;
       ctx.textBaseline = "middle";
       ctx.textAlign = "center";
+      // Using scale here to control how large the drawn font is
+      // We can't just use ctx.font since the lowest that can be on some browsers is 1px
+      ctx.scale(this.edgeLengthScale, this.edgeLengthScale);
       for (let i = 0; i < this._edgeLengthPositions.length; i++) {
         const length = this._edgeLengths[i].toString();
         const pos = this._edgeLengthPositions[i];
         ctx.fillText(length + " ft", pos.x, pos.y);
       }
+      // Reset scale to what is was previously
+      ctx.scale(1 / this.edgeLengthScale, 1 / this.edgeLengthScale);
       ctx.globalAlpha = 1.0;
     }
   }


### PR DESCRIPTION
- Adds edge lengths to room editor
- Adds button (ruler icon in top right) that toggle whether or not to show edge lengths (although the edge lengths will always show regardless when editing the room bounds)
- Adds tooltips (text shown when hovering) to the icon buttons within the room editor
<img width="500" alt="Screen Shot 2022-03-15 at 6 03 06 PM" src="https://user-images.githubusercontent.com/54820894/158479990-5547d065-1aaf-46d9-becb-c78b3fe92793.png">

It is possible for the text to overlap as seen below but I don't think its that big of a deal

<img width="400" alt="Screen Shot 2022-03-15 at 5 47 46 PM" src="https://user-images.githubusercontent.com/54820894/158480066-b8a7b034-be90-4c34-ad2c-c6beffa01668.png">

